### PR TITLE
Topic/annotated abts

### DIFF
--- a/node/src/Unison/ABT/Extra.hs
+++ b/node/src/Unison/ABT/Extra.hs
@@ -21,10 +21,12 @@ import qualified Data.Map as Map
 import qualified Data.Vector as Vector
 import qualified Unison.Digest as Digest
 
-hash :: forall f . (Foldable f, Digest.Digestable1 f) => Term f -> Digest.Hash
+-- | We ignore annotations in the `Term`, as these should never affect the
+-- meaning of the term.
+hash :: forall f a . (Foldable f, Digest.Digestable1 f) => Term f a -> Digest.Hash
 hash t = hash' [] t where
-  hash' :: [Either [V] V] -> Term f -> Digest.Hash
-  hash' env (Term _ t) = case t of
+  hash' :: [Either [V] V] -> Term f a -> Digest.Hash
+  hash' env (Term _ _ t) = case t of
     Var v -> maybe die hashInt ind
       where lookup (Left cycle) = elem v cycle
             lookup (Right v') = v == v'
@@ -38,7 +40,7 @@ hash t = hash' [] t where
     Abs v t -> hash' (Right v : env) t
     Tm t -> Digest.digest1 (hashCycle env) (hash' env) $ t
 
-  hashCycle :: [Either [V] V] -> [Term f] -> Digest.DigestM (Term f -> Digest.Hash)
+  hashCycle :: [Either [V] V] -> [Term f a] -> Digest.DigestM (Term f a -> Digest.Hash)
   hashCycle env@(Left cycle : envTl) ts | length cycle == length ts =
     let
       permute p xs = case Vector.fromList xs of xs -> map (xs !) p
@@ -51,27 +53,30 @@ hash t = hash' [] t where
   hashCycle env ts = Foldable.traverse_ (serialize . hash' env) ts *> pure (hash' env)
 
 -- | Use the `hash` function to efficiently remove duplicates from the list, preserving order.
-distinct :: (Foldable f, Digest.Digestable1 f) => [Term f] -> [Term f]
+distinct :: (Foldable f, Digest.Digestable1 f) => [Term f a] -> [Term f a]
 distinct ts = map fst (sortBy (comparing snd) m)
   where m = Map.elems (Map.fromList (map hash ts `zip` (ts `zip` [0 :: Int .. 1])))
 
 -- | Use the `hash` function to remove elements from `t1s` that exist in `t2s`, preserving order.
-subtract :: (Foldable f, Digest.Digestable1 f) => [Term f] -> [Term f] -> [Term f]
+subtract :: (Foldable f, Digest.Digestable1 f) => [Term f a] -> [Term f a] -> [Term f a]
 subtract t1s t2s =
   let skips = Set.fromList (map hash t2s)
   in filter (\t -> Set.notMember (hash t) skips) t1s
 
-instance (Foldable f, Serial1 f) => Serial (Term f) where
-  serialize (Term _ e) = case e of
+instance (Foldable f, Serial a, Serial1 f) => Serial (Term f a) where
+  serialize (Term _ a e) = serialize a *> case e of
     Var v -> Put.putWord8 0 *> serialize v
     Cycle body -> Put.putWord8 1 *> serialize body
     Abs v body -> Put.putWord8 2 *> serialize v *> serialize body
     Tm v -> Put.putWord8 3 *> serializeWith serialize v
 
-  deserialize = Get.getWord8 >>= \b -> case b of
-    0 -> var <$> deserialize
-    1 -> cycle <$> deserialize
-    2 -> abs <$> deserialize <*> deserialize
-    3 -> tm <$> deserializeWith deserialize
-    _ -> fail ("unknown byte tag, expected one of {0,1,2}, got: " ++ show b)
+  deserialize = do
+    ann <- deserialize
+    b <- Get.getWord8
+    case b of
+      0 -> annotatedVar ann <$> deserialize
+      1 -> cycle' ann <$> deserialize
+      2 -> abs' ann <$> deserialize <*> deserialize
+      3 -> tm' ann <$> deserializeWith deserialize
+      _ -> fail ("unknown byte tag, expected one of {0,1,2}, got: " ++ show b)
 

--- a/node/src/Unison/Term/Extra.hs
+++ b/node/src/Unison/Term/Extra.hs
@@ -2,7 +2,6 @@
 
 module Unison.Term.Extra where
 
-import Control.Applicative
 import Data.Bytes.Serial
 import Data.Vector (Vector)
 import Data.Foldable (traverse_)

--- a/shared/src/Unison/ABT.hs
+++ b/shared/src/Unison/ABT.hs
@@ -49,9 +49,9 @@ isFreeIn v t = Set.member v (freeVars t)
 annotate :: a -> Term f a -> Term f a
 annotate a (Term fvs _ out) = Term fvs a out
 
--- | Alter all annotations in this tree using the supplied function.
-mapAnnotations :: Functor f => (a -> b) -> Term f a -> Term f b
-mapAnnotations f (Term fvs a sub) = Term fvs (f a) (fmap (mapAnnotations f) sub)
+-- | Modifies the annotations in this tree
+instance Functor f => Functor (Term f) where
+  fmap f (Term fvs a sub) = Term fvs (f a) (fmap (fmap f) sub)
 
 pattern Var' v <- Term _ _ (Var v)
 pattern Cycle' vs t <- Term _ _ (Cycle (AbsN' vs t))

--- a/shared/src/Unison/ABT.hs
+++ b/shared/src/Unison/ABT.hs
@@ -27,74 +27,99 @@ import qualified Unison.Symbol as Symbol
 
 type V = Symbol
 
-data ABT f a
+data ABT f r
   = Var V
-  | Cycle a
-  | Abs V a
-  | Tm (f a) deriving (Functor, Foldable, Traversable)
+  | Cycle r
+  | Abs V r
+  | Tm (f r) deriving (Functor, Foldable, Traversable)
 
-data Term f = Term { freeVars :: Set V, out :: ABT f (Term f) }
+-- | At each level in the tree, we store the set of free variables and
+-- a value of type `a`.
+data Term f a = Term { freeVars :: Set V, annotation :: a, out :: ABT f (Term f a) }
 
 -- | `True` if the term has no free variables, `False` otherwise
-isClosed :: Term f -> Bool
+isClosed :: Term f a -> Bool
 isClosed t = Set.null (freeVars t)
 
 -- | `True` if `v` is a member of the set of free variables of `t`
-isFreeIn :: V -> Term f -> Bool
+isFreeIn :: V -> Term f a -> Bool
 isFreeIn v t = Set.member v (freeVars t)
 
-pattern Var' v <- Term _ (Var v)
-pattern Cycle' vs t <- Term _ (Cycle (AbsN' vs t))
-pattern Abs' v body <- Term _ (Abs v body)
+-- | Replace the annotation with the given argument.
+annotate :: a -> Term f a -> Term f a
+annotate a (Term fvs _ out) = Term fvs a out
+
+-- | Alter all annotations in this tree using the supplied function.
+mapAnnotations :: Functor f => (a -> b) -> Term f a -> Term f b
+mapAnnotations f (Term fvs a sub) = Term fvs (f a) (fmap (mapAnnotations f) sub)
+
+pattern Var' v <- Term _ _ (Var v)
+pattern Cycle' vs t <- Term _ _ (Cycle (AbsN' vs t))
+pattern Abs' v body <- Term _ _ (Abs v body)
 pattern AbsN' vs body <- (unabs -> (vs, body))
-pattern Tm' f <- Term _ (Tm f)
+pattern Tm' f <- Term _ _ (Tm f)
 
 v' :: Text -> V
 v' = Symbol.prefix
 
-var :: V -> Term f
-var v = Term (Set.singleton v) (Var v)
+var :: V -> Term f ()
+var = annotatedVar ()
 
-var' :: Text -> Term f
+var' :: Text -> Term f ()
 var' v = var (Symbol.prefix v)
 
-abs :: V -> Term f -> Term f
-abs v body = Term (Set.delete v (freeVars body)) (Abs v body)
+annotatedVar :: a -> V -> Term f a
+annotatedVar a v = Term (Set.singleton v) a (Var v)
 
-tm :: Foldable f => f (Term f) -> Term f
-tm t = Term (Set.unions (fmap freeVars (Foldable.toList t)))
-            (Tm t)
+abs :: V -> Term f () -> Term f ()
+abs = abs' ()
 
-cycle :: Term f -> Term f
-cycle t = Term (freeVars t) (Cycle t)
+abs' :: a -> V -> Term f a -> Term f a
+abs' a v body = Term (Set.delete v (freeVars body)) a (Abs v body)
 
-into :: Foldable f => ABT f (Term f) -> Term f
-into abt = case abt of
-  Var x -> var x
-  Cycle t -> cycle t
-  Abs v a -> abs v a
-  Tm t -> tm t
+tm :: Foldable f => f (Term f ()) -> Term f ()
+tm = tm' ()
+
+tm' :: Foldable f => a -> f (Term f a) -> Term f a
+tm' a t =
+  Term (Set.unions (fmap freeVars (Foldable.toList t))) a (Tm t)
+
+cycle :: Term f () -> Term f ()
+cycle = cycle' ()
+
+cycle' :: a -> Term f a -> Term f a
+cycle' a t = Term (freeVars t) a (Cycle t)
+
+into :: Foldable f => ABT f (Term f ()) -> Term f ()
+into = into' ()
+
+into' :: Foldable f => a -> ABT f (Term f a) -> Term f a
+into' a abt = case abt of
+  Var x -> annotatedVar a x
+  Cycle t -> cycle' a t
+  Abs v r -> abs' a v r
+  Tm t -> tm' a t
 
 -- | renames `old` to `new` in the given term, ignoring subtrees that bind `old`
-rename :: (Foldable f, Functor f) => V -> V -> Term f -> Term f
-rename old new t0@(Term _ t) = case t of
-  Var v -> if v == old then var new else t0
-  Cycle body -> cycle (rename old new body)
-  Abs v body -> if v == old then abs v body
-                else abs v (rename old new body)
-  Tm v -> tm (fmap (rename old new) v)
+rename :: (Foldable f, Functor f) => V -> V -> Term f a -> Term f a
+rename old new t0@(Term _ ann t) = case t of
+  Var v -> if v == old then annotatedVar ann new else t0
+  Cycle body -> cycle' ann (rename old new body)
+  Abs v body -> if v == old then abs' ann v body
+                else abs' ann v (rename old new body)
+  Tm v -> tm' ann (fmap (rename old new) v)
 
 -- | Produce a variable which is free in both terms
-freshInBoth :: Term f -> Term f -> V -> V
+freshInBoth :: Term f a -> Term f a -> V -> V
 freshInBoth t1 t2 = fresh t2 . fresh t1
 
-fresh :: Term f -> V -> V
+fresh :: Term f a -> V -> V
 fresh t = fresh' (freeVars t)
 
 fresh' :: Set V -> V -> V
 fresh' used = Symbol.freshIn used
 
-freshes :: Term f -> [V] -> [V]
+freshes :: Term f a -> [V] -> [V]
 freshes t = freshes' (freeVars t)
 
 freshes' :: Set V -> [V] -> [V]
@@ -107,31 +132,34 @@ freshNamed' :: Set V -> Text -> V
 freshNamed' used n = fresh' used (v' n)
 
 -- | `subst t x body` substitutes `t` for `x` in `body`, avoiding capture
-subst :: (Foldable f, Functor f) => Term f -> V -> Term f -> Term f
+subst :: (Foldable f, Functor f) => Term f a -> V -> Term f a -> Term f a
 subst t x body = replace t match body where
   match (Var' v) = x == v
   match _ = False
 
 -- | `substs [(t1,v1), (t2,v2), ...] body` performs multiple simultaneous
 -- substitutions, avoiding capture
-substs :: (Foldable f, Functor f) => [(V, Term f)] -> Term f -> Term f
+substs :: (Foldable f, Functor f) => [(V, Term f a)] -> Term f a -> Term f a
 substs replacements body = foldr f body replacements where
   f (v, t) body = subst t v body
 
--- | `rewrite t f body` substitutes `t` for all maximal (outermost)
+-- | `replace t f body` substitutes `t` for all maximal (outermost)
 -- subterms matching the predicate `f` in `body`, avoiding capture.
-replace :: (Foldable f, Functor f) => Term f -> (Term f -> Bool) -> Term f -> Term f
-replace t f body = go t f body where
-  go t f body | f body = t
-  go t f body = case out body of
-    Var v -> var v
-    Cycle body -> cycle (go t f body)
-    Abs x e -> abs x' e'
-      where x' = freshInBoth t body x
-            -- rename x to something that cannot be captured by `t`
-            e' = if x /= x' then go t f (rename x x' e)
-                 else go t f e
-    Tm body -> tm (fmap (go t f) body)
+replace :: (Foldable f, Functor f)
+        => Term f a
+        -> (Term f a -> Bool)
+        -> Term f a
+        -> Term f a
+replace t f body | f body = t
+replace t f t2@(Term _ ann body) = case body of
+  Var v -> annotatedVar ann v
+  Cycle body -> cycle' ann (replace t f body)
+  Abs x e -> abs' ann x' e'
+    where x' = freshInBoth t t2 x
+          -- rename x to something that cannot be captured by `t`
+          e' = if x /= x' then replace t f (rename x x' e)
+               else replace t f e
+  Tm body -> tm' ann (fmap (replace t f) body)
 
 -- | `visit f t` applies an effectful function to each subtree of
 -- `t` and sequences the results. When `f` returns `Nothing`, `visit`
@@ -139,7 +167,7 @@ replace t f body = go t f body where
 -- `Just t2`, `visit` replaces the current subtree with `t2`. Thus:
 -- `visit (const Nothing) t == pure t` and
 -- `visit (const (Just (pure t2))) t == pure t2`
-visit :: (Traversable f, Applicative g) => (Term f -> Maybe (g (Term f))) -> Term f -> g (Term f)
+visit :: (Traversable f, Applicative g) => (Term f () -> Maybe (g (Term f ()))) -> Term f () -> g (Term f ())
 visit f t = case f t of
   Just gt -> gt
   Nothing -> case out t of
@@ -150,7 +178,7 @@ visit f t = case f t of
 
 -- | Apply an effectful function to an ABT tree top down, sequencing the results.
 visit' :: (Traversable f, Applicative g, Monad g)
-       => (f (Term f) -> g (f (Term f))) -> Term f -> g (Term f)
+       => (f (Term f ()) -> g (f (Term f ()))) -> Term f () -> g (Term f ())
 visit' f t = case out t of
   Var _ -> pure t
   Cycle body -> cycle <$> visit' f body
@@ -162,52 +190,57 @@ visit' f t = case out t of
 type Focus1 f a = f a -> Maybe (a, a -> f a)
 
 -- | Extract the subterm at a given path
-at :: Foldable f => [Focus1 f (Term f)] -> Term f -> Maybe (Term f)
+at :: Foldable f => [Focus1 f (Term f a)] ->  Term f a -> Maybe (Term f a)
 at path t = fst <$> focus path t
 
 -- | Modify the subterm a path points to
 modify :: Foldable f
-       => (Term f -> Term f) -> [Focus1 f (Term f)] -> Term f -> Maybe (Term f)
+       => (Term f a -> Term f a)
+       -> [Focus1 f (Term f a)]
+       -> Term f a
+       -> Maybe (Term f a)
 modify f path t = (\(t,replace) -> replace (f t)) <$> focus path t
 
 -- | Focus on a subterm, obtaining the subtree and a function to replace that subtree
 focus :: Foldable f
-      => [Focus1 f (Term f)] -> Term f -> Maybe (Term f, Term f -> Term f)
+      => [Focus1 f (Term f a)]
+      -> Term f a
+      -> Maybe (Term f a, Term f a -> Term f a)
 focus [] t = Just (t, id)
-focus path@(hd:tl) t = case out t of
+focus path@(hd:tl) (Term _ ann t) = case t of
   Var _ -> Nothing
   Cycle t ->
-    let f (t,replace) = (t, cycle . replace)
+    let f (t,replace) = (t, cycle' ann . replace)
     in f <$> focus path t
   Abs v t ->
-    let f (t,replace) = (t, abs v . replace)
+    let f (t,replace) = (t, abs' ann v . replace)
     in f <$> focus path t
   Tm ft -> do
     (sub,hreplace) <- hd ft
     (t,replace) <- focus tl sub
-    pure (t, tm . hreplace . replace)
+    pure (t, tm' ann . hreplace . replace)
 
 -- | Returns the longest prefix of the path which points to a subterm
 -- in which `v` is not bound.
-introducedAt :: V -> [Focus1 f (Term f)] -> Term f -> Maybe [Focus1 f (Term f)]
+introducedAt :: V -> [Focus1 f (Term f ())] -> Term f () -> Maybe [Focus1 f (Term f ())]
 introducedAt v path t = f =<< boundAlong path t where
   f bs = case dropWhile (\vs -> not (Set.member v vs)) (reverse bs) of
     [] -> if elem v (fst (unabs t)) then Just [] else Nothing
     p -> Just (take (length p) path)
 
 -- | Returns the set of variables in scope at the given path, if valid
-boundAt :: [Focus1 f (Term f)] -> Term f -> Maybe (Set V)
+boundAt :: [Focus1 f (Term f ())] -> Term f () -> Maybe (Set V)
 boundAt path t = f =<< boundAlong path t where
   f [] = Nothing
   f vs = Just (last vs)
 
 -- | Returns the set of variables in scope at the given path,
 -- or the empty set if path is invalid
-boundAt' :: [Focus1 f (Term f)] -> Term f -> Set V
+boundAt' :: [Focus1 f (Term f ())] -> Term f () -> Set V
 boundAt' path t = fromMaybe Set.empty (boundAt path t)
 
 -- | For each element of the input path, the set of variables in scope
-boundAlong :: [Focus1 f (Term f)] -> Term f -> Maybe [Set V]
+boundAlong :: [Focus1 f (Term f ())] -> Term f () -> Maybe [Set V]
 boundAlong path t = go Set.empty path t where
   go _ [] _ = Just []
   go env path@(hd:tl) t = case out t of
@@ -219,17 +252,17 @@ boundAlong path t = go Set.empty path t where
       tl <- go env tl t
       pure (env : tl)
 
-unabs :: Term f -> ([V], Term f)
-unabs (Term _ (Abs hd body)) =
+unabs :: Term f a -> ([V], Term f a)
+unabs (Term _ _ (Abs hd body)) =
   let (tl, body') = unabs body in (hd : tl, body')
 unabs t = ([], t)
 
-reabs :: [V] -> Term f -> Term f
+reabs :: [V] -> Term f () -> Term f ()
 reabs vs t = foldr abs t vs
 
-instance (Foldable f, Functor f, Eq1 f) => Eq (Term f) where
+instance (Foldable f, Functor f, Eq1 f, Eq a) => Eq (Term f a) where
   -- alpha equivalence, works by renaming any aligned Abs ctors to use a common fresh variable
-  t1 == t2 = go (out t1) (out t2) where
+  t1 == t2 = annotation t1 == annotation t2 && go (out t1) (out t2) where
     go (Var v) (Var v2) | v == v2 = True
     go (Cycle t1) (Cycle t2) = t1 == t2
     go (Abs v1 body1) (Abs v2 body2) =
@@ -239,25 +272,33 @@ instance (Foldable f, Functor f, Eq1 f) => Eq (Term f) where
     go (Tm f1) (Tm f2) = f1 ==# f2
     go _ _ = False
 
-instance J.ToJSON1 f => ToJSON (Term f) where
-  toJSON (Term _ e) = case e of
-    Var v -> J.array [J.text "Var", toJSON v]
-    Cycle body -> J.array [J.text "Cycle", toJSON body]
-    Abs v body -> J.array [J.text "Abs", J.array [toJSON v, toJSON body]]
-    Tm v -> J.array [J.text "Tm", J.toJSON1 v]
+instance (J.ToJSON1 f, ToJSON a) => ToJSON (Term f a) where
+  toJSON (Term _ a e) =
+    let
+      body = case e of
+        Var v -> J.array [J.text "Var", toJSON v]
+        Cycle body -> J.array [J.text "Cycle", toJSON body]
+        Abs v body -> J.array [J.text "Abs", J.array [toJSON v, toJSON body]]
+        Tm v -> J.array [J.text "Tm", J.toJSON1 v]
+    in
+      J.array [toJSON a, body]
 
-instance (Foldable f, J.FromJSON1 f) => FromJSON (Term f) where
+instance (Foldable f, J.FromJSON1 f, FromJSON a) => FromJSON (Term f a) where
   parseJSON j = do
-    t <- J.at0 (Aeson.withText "ABT.tag" pure) j
-    case t of
-      _ | t == "Var"   -> var <$> J.at 1 Aeson.parseJSON j
-      _ | t == "Cycle" -> cycle <$> J.at 1 Aeson.parseJSON j
-      _ | t == "Abs"   -> J.at 1 (\j -> abs <$> J.at 0 Aeson.parseJSON j <*> J.at 1 Aeson.parseJSON j) j
-      _ | t == "Tm"    -> tm <$> J.at 1 J.parseJSON1 j
-      _                -> fail ("unknown tag: " ++ Text.unpack t)
+    ann <- J.at 0 Aeson.parseJSON j
+    J.at 1 (\j -> do {
+      t <- J.at0 (Aeson.withText "ABT.tag" pure) j;
+      case t of
+        _ | t == "Var"   -> annotatedVar ann <$> J.at 1 Aeson.parseJSON j
+        _ | t == "Cycle" -> cycle' ann <$> J.at 1 Aeson.parseJSON j
+        _ | t == "Abs"   -> J.at 1 (\j -> abs' ann <$> J.at 0 Aeson.parseJSON j <*> J.at 1 Aeson.parseJSON j) j
+        _ | t == "Tm"    -> tm' ann <$> J.at 1 J.parseJSON1 j
+        _                -> fail ("unknown tag: " ++ Text.unpack t)
+    }) j
 
-instance Show1 f => Show (Term f) where
-  showsPrec p (Term _ out) = case out of
+instance Show1 f => Show (Term f a) where
+  -- annotations not shown
+  showsPrec p (Term _ _ out) = case out of
     Var v -> showsPrec 0 v
     Cycle body -> showsPrec p body
     Abs v body -> showParen True $ showsPrec 0 v . showString ". " . showsPrec p body

--- a/shared/src/Unison/Term.hs
+++ b/shared/src/Unison/Term.hs
@@ -57,8 +57,9 @@ data F a
   deriving (Eq,Foldable,Functor,Generic1,Traversable)
 
 -- | Terms are represented as ABTs over the base functor F.
-type Term = ABT.Term F
+type AnnotatedTerm a = ABT.Term F a
 
+type Term = AnnotatedTerm ()
 -- nicer pattern syntax
 
 pattern Var' v <- ABT.Var' v
@@ -70,7 +71,7 @@ pattern Ref' r <- (ABT.out -> ABT.Tm (Ref r))
 pattern App' f x <- (ABT.out -> ABT.Tm (App f x))
 pattern Ann' x t <- (ABT.out -> ABT.Tm (Ann x t))
 pattern Vector' xs <- (ABT.out -> ABT.Tm (Vector xs))
-pattern Lam' v body <- (ABT.out -> ABT.Tm (Lam (ABT.Term _ (ABT.Abs v body))))
+pattern Lam' v body <- (ABT.out -> ABT.Tm (Lam (ABT.Term _ _ (ABT.Abs v body))))
 pattern Let1' v b e <- (ABT.out -> ABT.Tm (Let b (ABT.Abs' v e)))
 pattern Let' bs e relet rec <- (unLets -> Just (bs,e,relet,rec))
 pattern LetRec' bs e <- (unLetRec -> Just (bs,e))

--- a/shared/src/Unison/Type.hs
+++ b/shared/src/Unison/Type.hs
@@ -50,7 +50,9 @@ instance Eq1 F where (==#) = (==)
 instance Show1 F where showsPrec1 = showsPrec
 
 -- | Terms are represented as ABTs over the base functor F.
-type Type = ABT.Term F
+type Type = ABT.Term F ()
+
+type AnnotatedType a = ABT.Term F a
 
 -- An environment for looking up type references
 type Env f = R.Reference -> Noted f Type


### PR DESCRIPTION
The `ABT.Term f` is now `Term f a`, where `a` is the type of annotations. Change was very surgical, and with the pattern synonyms, almost no code outside of `ABT.hs` needed to change.

There's also:

* a `Functor (ABT.Term f)` so you can use `fmap` to alter the annotations throughout the tree
* `annotation :: ABT.Term f a -> a` to get the annotation
* `annotate :: a -> ABT.Term f a -> ABT.Term f a` to set the annotation
* A number of functions in `ABT.hs` have been generalized to work with annotated terms. There might be a few that could be usefully generalized that I haven't done yet.

The `Unison.Term.Term` type alias is now an alias for `ABT.Term F ()`. I did it this way just to make the upgrade super easy, and also because the vast majority of the code doesn't deal with these annotations at all (and wouldn't have enough information to propagate the info in the annotations). There's `AnnotatedTerm` if you want to allow non-`()` annotations, likewise there is `Type` and `AnnotatedType`.

I'm thinking of merging this as is, and if we encounter places where it makes sense to generalize from `Type` to `AnnotatedType` or `Term` to `AnnotatedTerm`, then we can do that as needed. However, since it's often more complicated to generalize, I'd like to only do this in places where there's a compelling reason to do so, not just because.

I considered using a typeclass for handling propagation of annotations up the tree, but decided that was a bad idea. Annotations must be set explicitly, and there's no meaning attached to the annotations, you can stick anything in there.

Review by @int-index and @Ericson2314 

I'll probably merge sometime tomorrow if I don't think of any problems with this or neither of you has serious objections.