### PR TITLE
Make `Term` and `Type` agnostic to the type of variables, in prep for supporting rich function layou

### DIFF
--- a/node/default.nix
+++ b/node/default.nix
@@ -17,7 +17,7 @@ mkDerivation {
     transformers-compat unison-shared vector
   ];
   testDepends = [
-    base tasty tasty-hunit tasty-quickcheck tasty-smallcheck
+    base bytes tasty tasty-hunit tasty-quickcheck tasty-smallcheck
     unison-shared
   ];
   homepage = "http://unisonweb.org";

--- a/node/src/Unison/ABT/Extra.hs
+++ b/node/src/Unison/ABT/Extra.hs
@@ -12,7 +12,7 @@ import Data.Ord
 import Data.Vector ((!))
 import Prelude hiding (abs,cycle)
 import Unison.ABT
-import Unison.Symbol.Extra () -- `Serial` instances
+import Unison.Var (Var)
 import qualified Data.Bytes.Get as Get
 import qualified Data.Bytes.Put as Put
 import qualified Data.Set as Set
@@ -20,12 +20,13 @@ import qualified Data.Foldable as Foldable
 import qualified Data.Map as Map
 import qualified Data.Vector as Vector
 import qualified Unison.Digest as Digest
+import qualified Unison.Var as Var
 
 -- | We ignore annotations in the `Term`, as these should never affect the
 -- meaning of the term.
-hash :: forall f a . (Foldable f, Digest.Digestable1 f) => Term f a -> Digest.Hash
+hash :: forall f v a . (Foldable f, Digest.Digestable1 f, Var v) => Term f v a -> Digest.Hash
 hash t = hash' [] t where
-  hash' :: [Either [V] V] -> Term f a -> Digest.Hash
+  hash' :: [Either [v] v] -> Term f v a -> Digest.Hash
   hash' env (Term _ _ t) = case t of
     Var v -> maybe die hashInt ind
       where lookup (Left cycle) = elem v cycle
@@ -34,13 +35,13 @@ hash t = hash' [] t where
             -- env not likely to be very big, prefer to encode in one byte if possible
             hashInt :: Int -> Digest.Hash
             hashInt i = Digest.run (serialize (VarInt i))
-            die = error $ "unknown var in environment: " ++ show v
+            die = error $ "unknown var in environment: " ++ show (Var.name v)
     Cycle (AbsN' vs t) -> hash' (Left vs : env) t
     Cycle t -> hash' env t
     Abs v t -> hash' (Right v : env) t
     Tm t -> Digest.digest1 (hashCycle env) (hash' env) $ t
 
-  hashCycle :: [Either [V] V] -> [Term f a] -> Digest.DigestM (Term f a -> Digest.Hash)
+  hashCycle :: [Either [v] v] -> [Term f v a] -> Digest.DigestM (Term f v a -> Digest.Hash)
   hashCycle env@(Left cycle : envTl) ts | length cycle == length ts =
     let
       permute p xs = case Vector.fromList xs of xs -> map (xs !) p
@@ -53,17 +54,17 @@ hash t = hash' [] t where
   hashCycle env ts = Foldable.traverse_ (serialize . hash' env) ts *> pure (hash' env)
 
 -- | Use the `hash` function to efficiently remove duplicates from the list, preserving order.
-distinct :: (Foldable f, Digest.Digestable1 f) => [Term f a] -> [Term f a]
+distinct :: (Foldable f, Digest.Digestable1 f, Var v) => [Term f v a] -> [Term f v a]
 distinct ts = map fst (sortBy (comparing snd) m)
   where m = Map.elems (Map.fromList (map hash ts `zip` (ts `zip` [0 :: Int .. 1])))
 
 -- | Use the `hash` function to remove elements from `t1s` that exist in `t2s`, preserving order.
-subtract :: (Foldable f, Digest.Digestable1 f) => [Term f a] -> [Term f a] -> [Term f a]
+subtract :: (Foldable f, Digest.Digestable1 f, Var v) => [Term f v a] -> [Term f v a] -> [Term f v a]
 subtract t1s t2s =
   let skips = Set.fromList (map hash t2s)
   in filter (\t -> Set.notMember (hash t) skips) t1s
 
-instance (Foldable f, Serial a, Serial1 f) => Serial (Term f a) where
+instance (Foldable f, Serial a, Serial v, Ord v, Serial1 f) => Serial (Term f v a) where
   serialize (Term _ a e) = serialize a *> case e of
     Var v -> Put.putWord8 0 *> serialize v
     Cycle body -> Put.putWord8 1 *> serialize body

--- a/node/src/Unison/Hash/Extra.hs
+++ b/node/src/Unison/Hash/Extra.hs
@@ -1,7 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Unison.Hash.Extra where
 
-import Control.Applicative
 import Data.Bytes.Serial
 import Unison.Hash
 

--- a/node/src/Unison/Node.hs
+++ b/node/src/Unison/Node.hs
@@ -17,31 +17,37 @@ import qualified Unison.Metadata as Metadata
 -- that previously returned incomplete results. Appending characters to a
 -- search that returned complete results just filters down the set and
 -- can be done client-side, assuming the client has the full result set.
-data SearchResults k t e =
+data SearchResults v h t e =
   SearchResults
     { query :: Metadata.Query
-    , references :: [(k, Metadata k)]
+    , references :: [(h, Metadata v h)]
     , matches :: ([e], Int)
     , illTypedMatches :: ([e], Int)
     , positionsExamined :: [Int] }
 
 deriveJSON defaultOptions ''SearchResults
 
-data Node m k t e = Node {
+-- | The Unison Node API:
+--   * `m` is the monad
+--   * `v` is the type of variables
+--   * `h` is the type of hashes
+--   * `t` is for type
+--   * `e` is for term (pnemonic "expression")
+data Node m v h t e = Node {
   -- | Obtain the type of the given subterm, assuming the path is valid
   admissibleTypeAt :: e -> Term.Path -> Noted m t,
   -- | Create a new term and provide its metadata
-  createTerm :: e -> Metadata k -> Noted m k,
+  createTerm :: e -> Metadata v h -> Noted m h,
   -- | Create a new type and provide its metadata
-  createType :: t -> Metadata k -> Noted m k,
+  createType :: t -> Metadata v h -> Noted m h,
   -- | Lookup the direct dependencies of @k@, optionally limited to the given set
-  dependencies :: Maybe (Set k) -> k -> Noted m (Set k),
+  dependencies :: Maybe (Set h) -> h -> Noted m (Set h),
   -- | Lookup the set of terms/types depending directly on the given @k@, optionally limited to the given set
-  dependents :: Maybe (Set k) -> k -> Noted m (Set k),
+  dependents :: Maybe (Set h) -> h -> Noted m (Set h),
   -- | Modify the given subterm, which may fail. First argument is the root path.
   -- Second argument is path relative to the root.
   -- Returns (root path, original e, edited e, new cursor position)
-  editTerm :: Term.Path -> Term.Path -> Action -> e -> Noted m (Maybe (Term.Path,e,e,Term.Path)),
+  editTerm :: Term.Path -> Term.Path -> Action v -> e -> Noted m (Maybe (Term.Path,e,e,Term.Path)),
   -- Evaluate all terms, returning a list of (path, original e, evaluated e)
   evaluateTerms :: [(Term.Path, e)] -> Noted m [(Term.Path,e,e)],
   -- | Returns ( subterm at the given path
@@ -53,22 +59,19 @@ data Node m k t e = Node {
   -- | Modify the given subterm, which may fail. First argument is the root path.
   localInfo :: e -> Term.Path -> Noted m (e, t, t, [e], [Int], [e]),
   -- | Access the metadata for the term and/or types identified by @k@
-  metadatas :: [k] -> Noted m (Map k (Metadata k)),
+  metadatas :: [h] -> Noted m (Map h (Metadata v h)),
   -- | Search for a term, optionally constrained to be of the given type
-  search :: e -> Term.Path -> Int -> Metadata.Query -> Maybe t -> Noted m (SearchResults k t e),
-  -- | Lookup the source of the term identified by @k@
-  terms :: [k] -> Noted m (Map k e),
-  -- | Lookup the dependencies of @k@, optionally limited to those that intersect the given set
-  transitiveDependencies :: Maybe (Set k) -> k -> Noted m (Set k),
+  search :: e -> Term.Path -> Int -> Metadata.Query -> Maybe t -> Noted m (SearchResults v h t e),
+  -- | Lookup the source of the term identified by @h@
+  terms :: [h] -> Noted m (Map h e),
+  -- | Lookup the dependencies of @h@, optionally limited to those that intersect the given set
+  transitiveDependencies :: Maybe (Set h) -> h -> Noted m (Set h),
   -- | Lookup the set of terms or types which depend on the given @k@, optionally limited to those that intersect the given set
-  transitiveDependents :: Maybe (Set k) -> k -> Noted m (Set k),
-  -- | Lookup the source of the type identified by @k@
-  types :: [k] -> Noted m (Map k t),
+  transitiveDependents :: Maybe (Set h) -> h -> Noted m (Set h),
+  -- | Lookup the source of the type identified by @h@
+  types :: [h] -> Noted m (Map h t),
   -- | Obtain the type of the given subterm, assuming the path is valid
   typeAt :: e -> Term.Path -> Noted m t,
   -- | Update the metadata associated with the given term or type
-  updateMetadata :: k -> Metadata k -> Noted m ()
+  updateMetadata :: h -> Metadata v h -> Noted m ()
 }
-
-
-

--- a/node/src/Unison/Node/Implementation.hs
+++ b/node/src/Unison/Node/Implementation.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE PatternSynonyms #-}
 module Unison.Node.Implementation (node) where
 
-import Control.Applicative
 import Control.Monad
+import Data.Bytes.Serial (Serial)
 import Data.List
 import Data.Ord
 import Unison.Eval as Eval
@@ -13,6 +13,7 @@ import Unison.Term.Extra ()
 import Unison.Type (Type)
 import Unison.Node.Store (Store)
 import Unison.Note (Noted)
+import Unison.Var (Var)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Unison.ABT.Extra as ABT'
@@ -36,7 +37,10 @@ import qualified Unison.Node.Store as Store
 --watches :: (Foldable f, Show a) => String -> f a -> f a
 --watches msg as = trace (msg ++ ":\n" ++ intercalate "\n" (map show (Foldable.toList as)) ++ "\n.") as
 
-node :: (Applicative f, Monad f) => Eval (Noted f) -> Store f -> Node f Reference.Reference Type Term
+node :: (Monad f, Var v, Serial v)
+     => Eval (Noted f) v
+     -> Store f v
+     -> Node f v Reference.Reference (Type v) (Term v)
 node eval store =
   let
     readTypeOf = Store.typeOfTerm store
@@ -160,4 +164,3 @@ node eval store =
        types
        typeAt
        updateMetadata
-

--- a/node/src/Unison/Node/Store.hs
+++ b/node/src/Unison/Node/Store.hs
@@ -22,18 +22,20 @@ import qualified Unison.Hash as Hash
 import qualified Unison.Note as Note
 import qualified Unison.Reference as Reference
 
-data Store f = Store {
+-- todo may want to just bind v here
+
+data Store f v = Store {
   hashes :: Maybe (Set Reference) -> Noted f (Set Reference), -- ^ The set of hashes in this store, optionally constrained to intersect the given set
-  readTerm :: Hash -> Noted f Term,
-  writeTerm :: Hash -> Term -> Noted f (),
-  typeOfTerm :: Reference -> Noted f Type,
-  annotateTerm :: Reference -> Type -> Noted f (),
-  readMetadata :: Reference -> Noted f (Metadata Reference),
-  writeMetadata :: Reference -> Metadata Reference -> Noted f ()
+  readTerm :: Hash -> Noted f (Term v),
+  writeTerm :: Hash -> Term v -> Noted f (),
+  typeOfTerm :: Reference -> Noted f (Type v),
+  annotateTerm :: Reference -> Type v -> Noted f (),
+  readMetadata :: Reference -> Noted f (Metadata v Reference),
+  writeMetadata :: Reference -> Metadata v Reference -> Noted f ()
 }
 
 -- | Create a 'Store' rooted at the given path.
-store :: FilePath -> IO (Store IO)
+store :: (Ord v, ToJSON v, FromJSON v) => FilePath -> IO (Store IO v)
 store root =
   let
     hashesIn :: (String -> Reference) -> FilePath -> Noted IO (Set Reference)

--- a/node/src/Unison/NodeServer.hs
+++ b/node/src/Unison/NodeServer.hs
@@ -5,11 +5,14 @@
 module Unison.NodeServer where
 
 import Control.Monad.IO.Class
+import Data.Aeson (ToJSON, FromJSON)
 import Network.HTTP.Types.Method (StdMethod(OPTIONS))
 import Unison.Hash (Hash)
 import Unison.Node (Node)
 import Unison.Note (Noted, unnote)
 import Unison.Reference (Reference)
+import Unison.Term (Term)
+import Unison.Type (Type)
 import Web.Scotty (ActionM)
 import qualified Data.Aeson as J
 import qualified Data.Aeson.Parser as JP
@@ -58,7 +61,7 @@ route action = do
 postRoute :: S.RoutePattern -> ActionM () -> S.ScottyM ()
 postRoute s action = S.post s (route action)
 
-server :: Int -> Node IO Reference T.Type E.Term -> IO ()
+server :: (Ord v, ToJSON v, FromJSON v) => Int -> Node IO v Reference (Type v) (Term v) -> IO ()
 server port node = S.scotty port $ do
   S.addroute OPTIONS (S.regex ".*") $ originOptions
   postRoute "/admissible-type-at" $ do

--- a/node/src/Unison/Symbol/Extra.hs
+++ b/node/src/Unison/Symbol/Extra.hs
@@ -1,21 +1,13 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Unison.Symbol.Extra where
 
-import Control.Applicative
 import Unison.Symbol
 import Data.Bytes.Serial (Serial(..))
 import Data.Bytes.VarInt
 
-instance Serial Fixity where
-  serialize = serialize . VarInt . fromEnum
-  deserialize = toEnum . unVarInt <$> deserialize
-
-instance Serial Symbol where
-  serialize (Symbol i n f p) =
-    serialize (VarInt i) *> serialize n *> serialize f *> serialize (VarInt p)
+instance Serial a => Serial (Symbol a) where
+  serialize (Symbol i n a) =
+    serialize (VarInt i) *> serialize n *> serialize a
   deserialize =
-    Symbol <$> (unVarInt <$> deserialize)
-           <*> deserialize
-           <*> deserialize
-           <*> (unVarInt <$> deserialize)
+    Symbol <$> (unVarInt <$> deserialize) <*> deserialize <*> deserialize
 

--- a/node/src/Unison/Term/Extra.hs
+++ b/node/src/Unison/Term/Extra.hs
@@ -17,7 +17,7 @@ import qualified Unison.Hash as Hash
 import qualified Unison.Reference as Reference
 
 instance Serial Literal
-instance Serial1 F where
+instance (Serial v, Ord v) => Serial1 (F v) where
   serializeWith f e = case e of
     Lit l -> Put.putWord8 0 *> serialize l
     Blank -> Put.putWord8 1
@@ -44,7 +44,7 @@ instance Serial1 Vector where
   serializeWith f vs = serialize (Vector.length vs) *> traverse_ f vs
   deserializeWith v = deserialize >>= \len -> sequence (Vector.replicate len v)
 
-instance Digest.Digestable1 F where
+instance (Serial v, Ord v) => Digest.Digestable1 (F v) where
   digest1 hashCycle hash e = case e of
     -- References are 'transparent' wrt hash - we return the precomputed hash,
     -- so for example `x = 1 + 1` and `y = x` hash the same. Thus hashing is

--- a/node/src/Unison/TermEdit/Extra.hs
+++ b/node/src/Unison/TermEdit/Extra.hs
@@ -6,4 +6,4 @@ import Data.Bytes.Serial
 import Unison.Symbol.Extra ()
 import Unison.TermEdit
 
-instance Serial Action
+instance Serial v => Serial (Action v)

--- a/node/tests/Unison/Test/Term.hs
+++ b/node/tests/Unison/Test/Term.hs
@@ -4,17 +4,23 @@ module Unison.Test.Term where
 import Unison.Term
 import Unison.Term.Extra ()
 import Unison.Reference as R
+import Unison.Var (Var)
+import Unison.Symbol (Symbol)
+import Unison.Symbol.Extra ()
 import Test.Tasty
 -- import Test.Tasty.SmallCheck as SC
 -- import Test.Tasty.QuickCheck as QC
 import Test.Tasty.HUnit
 import qualified Unison.ABT.Extra as ABT
 
+-- term for testing
+type TTerm = Term (Symbol (Maybe ()))
+
 tests :: TestTree
 tests = testGroup "Term"
   [ testCase "alpha equivalence (term)" $ assertEqual "identity"
-     (lam' ["a"] $ var' "a")
-     (lam' ["x"] $ var' "x")
+     ((lam' ["a"] $ var' "a") :: TTerm)
+      (lam' ["x"] $ var' "x")
   , testCase "hash cycles" $ assertEqual "pingpong"
      (ABT.hash pingpong1)
      (ABT.hash pingpong2)
@@ -22,37 +28,37 @@ tests = testGroup "Term"
 
 -- various unison terms, useful for testing
 
-id :: Term
+id :: TTerm
 id = lam' ["a"] $ var' "a"
 
-const :: Term
+const :: TTerm
 const = lam' ["x", "y"] $ var' "x"
 
-one :: Term
+one :: TTerm
 one = num 1
 
-zero :: Term
+zero :: TTerm
 zero = num 0
 
-plus :: Term -> Term -> Term
+plus :: TTerm -> TTerm -> TTerm
 plus a b = ref (R.Builtin "+") `app` a `app` b
 
-minus :: Term -> Term -> Term
+minus :: TTerm -> TTerm -> TTerm
 minus a b = ref (R.Builtin "-") `app` a `app` b
 
-fix :: Term
+fix :: TTerm
 fix = letRec'
   [ ("fix", lam' ["f"] $ var' "f" `app` (var' "fix" `app` var' "f")) ]
   (var' "fix")
 
-pingpong1 :: Term
+pingpong1 :: TTerm
 pingpong1 =
   letRec'
     [ ("ping", lam' ["x"] $ var' "pong" `app` (plus (var' "x") one))
     , ("pong", lam' ["y"] $ var' "pong" `app` (minus (var' "y") one)) ]
     (var' "ping" `app` one)
 
-pingpong2 :: Term
+pingpong2 :: TTerm
 pingpong2 =
   letRec'
     [ ("pong1", lam' ["p"] $ var' "pong1" `app` (minus (var' "p") one))

--- a/node/unison-node.cabal
+++ b/node/unison-node.cabal
@@ -136,6 +136,7 @@ test-suite tests
   else
     build-depends:
       base,
+      bytes,
       tasty,
       tasty-hunit,
       tasty-smallcheck,

--- a/shared/src/Unison/ABT.hs
+++ b/shared/src/Unison/ABT.hs
@@ -10,7 +10,6 @@
 
 module Unison.ABT where
 
-import Data.Aeson.TH
 import Data.Aeson (ToJSON(..),FromJSON(..))
 import Data.List hiding (cycle)
 import Data.Maybe
@@ -19,7 +18,6 @@ import Data.Text (Text)
 import Data.Traversable
 import Prelude hiding (abs,cycle)
 import Prelude.Extras (Eq1(..), Show1(..))
-import Unison.Symbol (Symbol)
 import Unison.Var (Var)
 import qualified Data.Aeson as Aeson
 import qualified Data.Foldable as Foldable

--- a/shared/src/Unison/ABT.hs
+++ b/shared/src/Unison/ABT.hs
@@ -1,14 +1,16 @@
 -- Based on: http://semantic-domain.blogspot.com/2015/03/abstract-binding-trees.html
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Unison.ABT where
 
+import Data.Aeson.TH
 import Data.Aeson (ToJSON(..),FromJSON(..))
 import Data.List hiding (cycle)
 import Data.Maybe
@@ -18,39 +20,39 @@ import Data.Traversable
 import Prelude hiding (abs,cycle)
 import Prelude.Extras (Eq1(..), Show1(..))
 import Unison.Symbol (Symbol)
+import Unison.Var (Var)
 import qualified Data.Aeson as Aeson
 import qualified Data.Foldable as Foldable
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Unison.JSON as J
-import qualified Unison.Symbol as Symbol
+import qualified Unison.Var as Var
 
-type V = Symbol
-
-data ABT f r
-  = Var V
+data ABT f v r
+  = Var v
   | Cycle r
-  | Abs V r
+  | Abs v r
   | Tm (f r) deriving (Functor, Foldable, Traversable)
 
 -- | At each level in the tree, we store the set of free variables and
--- a value of type `a`.
-data Term f a = Term { freeVars :: Set V, annotation :: a, out :: ABT f (Term f a) }
+-- a value of type `a`. Individual variables are annotated with a value of
+-- type `v`.
+data Term f v a = Term { freeVars :: Set v, annotation :: a, out :: ABT f v (Term f v a) }
 
 -- | `True` if the term has no free variables, `False` otherwise
-isClosed :: Term f a -> Bool
+isClosed :: Term f v a -> Bool
 isClosed t = Set.null (freeVars t)
 
 -- | `True` if `v` is a member of the set of free variables of `t`
-isFreeIn :: V -> Term f a -> Bool
+isFreeIn :: Ord v => v -> Term f v a -> Bool
 isFreeIn v t = Set.member v (freeVars t)
 
 -- | Replace the annotation with the given argument.
-annotate :: a -> Term f a -> Term f a
+annotate :: a -> Term f v a -> Term f v a
 annotate a (Term fvs _ out) = Term fvs a out
 
 -- | Modifies the annotations in this tree
-instance Functor f => Functor (Term f) where
+instance Functor f => Functor (Term f v) where
   fmap f (Term fvs a sub) = Term fvs (f a) (fmap (fmap f) sub)
 
 pattern Var' v <- Term _ _ (Var v)
@@ -59,41 +61,41 @@ pattern Abs' v body <- Term _ _ (Abs v body)
 pattern AbsN' vs body <- (unabs -> (vs, body))
 pattern Tm' f <- Term _ _ (Tm f)
 
-v' :: Text -> V
-v' = Symbol.prefix
+v' :: Var v => Text -> v
+v' = Var.named
 
-var :: V -> Term f ()
+var :: v -> Term f v ()
 var = annotatedVar ()
 
-var' :: Text -> Term f ()
-var' v = var (Symbol.prefix v)
+var' :: Var v => Text -> Term f v ()
+var' v = var (Var.named v)
 
-annotatedVar :: a -> V -> Term f a
+annotatedVar :: a -> v -> Term f v a
 annotatedVar a v = Term (Set.singleton v) a (Var v)
 
-abs :: V -> Term f () -> Term f ()
+abs :: Ord v => v -> Term f v () -> Term f v ()
 abs = abs' ()
 
-abs' :: a -> V -> Term f a -> Term f a
+abs' :: Ord v => a -> v -> Term f v a -> Term f v a
 abs' a v body = Term (Set.delete v (freeVars body)) a (Abs v body)
 
-tm :: Foldable f => f (Term f ()) -> Term f ()
+tm :: (Foldable f, Ord v) => f (Term f v ()) -> Term f v ()
 tm = tm' ()
 
-tm' :: Foldable f => a -> f (Term f a) -> Term f a
+tm' :: (Foldable f, Ord v) => a -> f (Term f v a) -> Term f v a
 tm' a t =
   Term (Set.unions (fmap freeVars (Foldable.toList t))) a (Tm t)
 
-cycle :: Term f () -> Term f ()
+cycle :: Term f v () -> Term f v ()
 cycle = cycle' ()
 
-cycle' :: a -> Term f a -> Term f a
+cycle' :: a -> Term f v a -> Term f v a
 cycle' a t = Term (freeVars t) a (Cycle t)
 
-into :: Foldable f => ABT f (Term f ()) -> Term f ()
+into :: (Foldable f, Ord v) => ABT f v (Term f v ()) -> Term f v ()
 into = into' ()
 
-into' :: Foldable f => a -> ABT f (Term f a) -> Term f a
+into' :: (Foldable f, Ord v) => a -> ABT f v (Term f v a) -> Term f v a
 into' a abt = case abt of
   Var x -> annotatedVar a x
   Cycle t -> cycle' a t
@@ -101,7 +103,7 @@ into' a abt = case abt of
   Tm t -> tm' a t
 
 -- | renames `old` to `new` in the given term, ignoring subtrees that bind `old`
-rename :: (Foldable f, Functor f) => V -> V -> Term f a -> Term f a
+rename :: (Foldable f, Functor f, Var v) => v -> v -> Term f v a -> Term f v a
 rename old new t0@(Term _ ann t) = case t of
   Var v -> if v == old then annotatedVar ann new else t0
   Cycle body -> cycle' ann (rename old new body)
@@ -110,46 +112,43 @@ rename old new t0@(Term _ ann t) = case t of
   Tm v -> tm' ann (fmap (rename old new) v)
 
 -- | Produce a variable which is free in both terms
-freshInBoth :: Term f a -> Term f a -> V -> V
+freshInBoth :: Var v => Term f v a -> Term f v a -> v -> v
 freshInBoth t1 t2 = fresh t2 . fresh t1
 
-fresh :: Term f a -> V -> V
+fresh :: Var v => Term f v a -> v -> v
 fresh t = fresh' (freeVars t)
 
-fresh' :: Set V -> V -> V
-fresh' used = Symbol.freshIn used
+fresh' :: Var v => Set v -> v -> v
+fresh' used = Var.freshIn used
 
-freshes :: Term f a -> [V] -> [V]
-freshes t = freshes' (freeVars t)
+freshes :: Var v => Term f v a -> [v] -> [v]
+freshes t = Var.freshes (freeVars t)
 
-freshes' :: Set V -> [V] -> [V]
-freshes' _ [] = []
-freshes' used (h:t) =
-  let h' = fresh' used h
-  in h' : freshes' (Set.insert h' used) t
+freshes' :: Var v => Set v -> [v] -> [v]
+freshes' = Var.freshes
 
-freshNamed' :: Set V -> Text -> V
+freshNamed' :: Var v => Set v -> Text -> v
 freshNamed' used n = fresh' used (v' n)
 
 -- | `subst t x body` substitutes `t` for `x` in `body`, avoiding capture
-subst :: (Foldable f, Functor f) => Term f a -> V -> Term f a -> Term f a
+subst :: (Foldable f, Functor f, Var v) => Term f v a -> v -> Term f v a -> Term f v a
 subst t x body = replace t match body where
   match (Var' v) = x == v
   match _ = False
 
 -- | `substs [(t1,v1), (t2,v2), ...] body` performs multiple simultaneous
 -- substitutions, avoiding capture
-substs :: (Foldable f, Functor f) => [(V, Term f a)] -> Term f a -> Term f a
+substs :: (Foldable f, Functor f, Var v) => [(v, Term f v a)] -> Term f v a -> Term f v a
 substs replacements body = foldr f body replacements where
   f (v, t) body = subst t v body
 
 -- | `replace t f body` substitutes `t` for all maximal (outermost)
 -- subterms matching the predicate `f` in `body`, avoiding capture.
-replace :: (Foldable f, Functor f)
-        => Term f a
-        -> (Term f a -> Bool)
-        -> Term f a
-        -> Term f a
+replace :: (Foldable f, Functor f, Var v)
+        => Term f v a
+        -> (Term f v a -> Bool)
+        -> Term f v a
+        -> Term f v a
 replace t f body | f body = t
 replace t f t2@(Term _ ann body) = case body of
   Var v -> annotatedVar ann v
@@ -167,7 +166,10 @@ replace t f t2@(Term _ ann body) = case body of
 -- `Just t2`, `visit` replaces the current subtree with `t2`. Thus:
 -- `visit (const Nothing) t == pure t` and
 -- `visit (const (Just (pure t2))) t == pure t2`
-visit :: (Traversable f, Applicative g) => (Term f () -> Maybe (g (Term f ()))) -> Term f () -> g (Term f ())
+visit :: (Traversable f, Applicative g, Ord v)
+      => (Term f v () -> Maybe (g (Term f v ())))
+      -> Term f v ()
+      -> g (Term f v ())
 visit f t = case f t of
   Just gt -> gt
   Nothing -> case out t of
@@ -177,8 +179,10 @@ visit f t = case f t of
     Tm body -> tm <$> traverse (visit f) body
 
 -- | Apply an effectful function to an ABT tree top down, sequencing the results.
-visit' :: (Traversable f, Applicative g, Monad g)
-       => (f (Term f ()) -> g (f (Term f ()))) -> Term f () -> g (Term f ())
+visit' :: (Traversable f, Applicative g, Monad g, Ord v)
+       => (f (Term f v ()) -> g (f (Term f v ())))
+       -> Term f v ()
+       -> g (Term f v ())
 visit' f t = case out t of
   Var _ -> pure t
   Cycle body -> cycle <$> visit' f body
@@ -190,22 +194,22 @@ visit' f t = case out t of
 type Focus1 f a = f a -> Maybe (a, a -> f a)
 
 -- | Extract the subterm at a given path
-at :: Foldable f => [Focus1 f (Term f a)] ->  Term f a -> Maybe (Term f a)
+at :: (Foldable f, Ord v) => [Focus1 f (Term f v a)] -> Term f v a -> Maybe (Term f v a)
 at path t = fst <$> focus path t
 
 -- | Modify the subterm a path points to
-modify :: Foldable f
-       => (Term f a -> Term f a)
-       -> [Focus1 f (Term f a)]
-       -> Term f a
-       -> Maybe (Term f a)
+modify :: (Foldable f, Ord v)
+       => (Term f v a -> Term f v a)
+       -> [Focus1 f (Term f v a)]
+       -> Term f v a
+       -> Maybe (Term f v a)
 modify f path t = (\(t,replace) -> replace (f t)) <$> focus path t
 
 -- | Focus on a subterm, obtaining the subtree and a function to replace that subtree
-focus :: Foldable f
-      => [Focus1 f (Term f a)]
-      -> Term f a
-      -> Maybe (Term f a, Term f a -> Term f a)
+focus :: (Foldable f, Ord v)
+      => [Focus1 f (Term f v a)]
+      -> Term f v a
+      -> Maybe (Term f v a, Term f v a -> Term f v a)
 focus [] t = Just (t, id)
 focus path@(hd:tl) (Term _ ann t) = case t of
   Var _ -> Nothing
@@ -222,25 +226,25 @@ focus path@(hd:tl) (Term _ ann t) = case t of
 
 -- | Returns the longest prefix of the path which points to a subterm
 -- in which `v` is not bound.
-introducedAt :: V -> [Focus1 f (Term f ())] -> Term f () -> Maybe [Focus1 f (Term f ())]
+introducedAt :: Ord v => v -> [Focus1 f (Term f v ())] -> Term f v () -> Maybe [Focus1 f (Term f v ())]
 introducedAt v path t = f =<< boundAlong path t where
   f bs = case dropWhile (\vs -> not (Set.member v vs)) (reverse bs) of
     [] -> if elem v (fst (unabs t)) then Just [] else Nothing
     p -> Just (take (length p) path)
 
 -- | Returns the set of variables in scope at the given path, if valid
-boundAt :: [Focus1 f (Term f ())] -> Term f () -> Maybe (Set V)
+boundAt :: Ord v => [Focus1 f (Term f v ())] -> Term f v () -> Maybe (Set v)
 boundAt path t = f =<< boundAlong path t where
   f [] = Nothing
   f vs = Just (last vs)
 
 -- | Returns the set of variables in scope at the given path,
 -- or the empty set if path is invalid
-boundAt' :: [Focus1 f (Term f ())] -> Term f () -> Set V
+boundAt' :: Ord v => [Focus1 f (Term f v ())] -> Term f v () -> Set v
 boundAt' path t = fromMaybe Set.empty (boundAt path t)
 
 -- | For each element of the input path, the set of variables in scope
-boundAlong :: [Focus1 f (Term f ())] -> Term f () -> Maybe [Set V]
+boundAlong :: Ord v => [Focus1 f (Term f v ())] -> Term f v () -> Maybe [Set v]
 boundAlong path t = go Set.empty path t where
   go _ [] _ = Just []
   go env path@(hd:tl) t = case out t of
@@ -252,15 +256,15 @@ boundAlong path t = go Set.empty path t where
       tl <- go env tl t
       pure (env : tl)
 
-unabs :: Term f a -> ([V], Term f a)
+unabs :: Term f v a -> ([v], Term f v a)
 unabs (Term _ _ (Abs hd body)) =
   let (tl, body') = unabs body in (hd : tl, body')
 unabs t = ([], t)
 
-reabs :: [V] -> Term f () -> Term f ()
+reabs :: Ord v => [v] -> Term f v () -> Term f v ()
 reabs vs t = foldr abs t vs
 
-instance (Foldable f, Functor f, Eq1 f, Eq a) => Eq (Term f a) where
+instance (Foldable f, Functor f, Eq1 f, Eq a, Var v) => Eq (Term f v a) where
   -- alpha equivalence, works by renaming any aligned Abs ctors to use a common fresh variable
   t1 == t2 = annotation t1 == annotation t2 && go (out t1) (out t2) where
     go (Var v) (Var v2) | v == v2 = True
@@ -272,7 +276,7 @@ instance (Foldable f, Functor f, Eq1 f, Eq a) => Eq (Term f a) where
     go (Tm f1) (Tm f2) = f1 ==# f2
     go _ _ = False
 
-instance (J.ToJSON1 f, ToJSON a) => ToJSON (Term f a) where
+instance (J.ToJSON1 f, ToJSON v, ToJSON a) => ToJSON (Term f v a) where
   toJSON (Term _ a e) =
     let
       body = case e of
@@ -283,7 +287,7 @@ instance (J.ToJSON1 f, ToJSON a) => ToJSON (Term f a) where
     in
       J.array [toJSON a, body]
 
-instance (Foldable f, J.FromJSON1 f, FromJSON a) => FromJSON (Term f a) where
+instance (Foldable f, J.FromJSON1 f, FromJSON v, Ord v, FromJSON a) => FromJSON (Term f v a) where
   parseJSON j = do
     ann <- J.at 0 Aeson.parseJSON j
     J.at 1 (\j -> do {
@@ -296,7 +300,7 @@ instance (Foldable f, J.FromJSON1 f, FromJSON a) => FromJSON (Term f a) where
         _                -> fail ("unknown tag: " ++ Text.unpack t)
     }) j
 
-instance Show1 f => Show (Term f a) where
+instance (Show1 f, Show v) => Show (Term f v a) where
   -- annotations not shown
   showsPrec p (Term _ _ out) = case out of
     Var v -> showsPrec 0 v

--- a/shared/src/Unison/ABT.hs
+++ b/shared/src/Unison/ABT.hs
@@ -298,10 +298,10 @@ instance (Foldable f, J.FromJSON1 f, FromJSON v, Ord v, FromJSON a) => FromJSON 
         _                -> fail ("unknown tag: " ++ Text.unpack t)
     }) j
 
-instance (Show1 f, Show v) => Show (Term f v a) where
+instance (Show1 f, Var v) => Show (Term f v a) where
   -- annotations not shown
   showsPrec p (Term _ _ out) = case out of
-    Var v -> showsPrec 0 v
+    Var v -> showsPrec 0 (Var.shortName v)
     Cycle body -> showsPrec p body
-    Abs v body -> showParen True $ showsPrec 0 v . showString ". " . showsPrec p body
+    Abs v body -> showParen True $ showsPrec 0 (Var.shortName v) . showString ". " . showsPrec p body
     Tm f -> showsPrec1 p f

--- a/shared/src/Unison/Eval.hs
+++ b/shared/src/Unison/Eval.hs
@@ -3,7 +3,7 @@ module Unison.Eval where
 import Unison.Hash (Hash)
 import Unison.Term (Term)
 
-data Eval m = Eval {
-  whnf :: (Hash -> m Term) -> Term -> m Term, -- ^ Simplify to weak head normal form
-  step :: (Hash -> m Term) -> Term -> m Term  -- ^ Perform one beta reduction
+data Eval m v = Eval {
+  whnf :: (Hash -> m (Term v)) -> Term v -> m (Term v), -- ^ Simplify to weak head normal form
+  step :: (Hash -> m (Term v)) -> Term v -> m (Term v)  -- ^ Perform one beta reduction
 }

--- a/shared/src/Unison/Metadata.hs
+++ b/shared/src/Unison/Metadata.hs
@@ -10,23 +10,23 @@ import qualified Unison.Var as Var
 
 data Sort = Type | Term deriving (Eq,Ord,Show)
 
-data Metadata v r =
+data Metadata v h =
   Metadata {
     sort :: Sort,
     names :: Names v,
-    description :: Maybe r
+    description :: Maybe h
   } deriving (Eq,Ord,Show)
 
-matches :: Var v => Query -> Metadata v r -> Bool
+matches :: Var v => Query -> Metadata v h -> Bool
 matches (Query txt) (Metadata _ (Names ns) _) =
   any (Text.isPrefixOf txt) (map Var.name ns)
 
 -- | Nameless metadata, contains only the annotation
-synthetic :: Sort -> Metadata v r
+synthetic :: Sort -> Metadata v h
 synthetic t = Metadata t (Names []) Nothing
 
 -- | Nameless term metadata, containing only the type annotation
-syntheticTerm :: Metadata v r
+syntheticTerm :: Metadata v h
 syntheticTerm = synthetic Term
 
 data Names v = Names [v] deriving (Eq,Ord,Show)

--- a/shared/src/Unison/Metadata.hs
+++ b/shared/src/Unison/Metadata.hs
@@ -4,34 +4,32 @@ module Unison.Metadata where
 import Data.Aeson
 import Data.Aeson.TH
 import Data.Text (Text)
-import Unison.Symbol (Symbol)
+import Unison.Var (Var)
 import qualified Data.Text as Text
-import qualified Unison.Symbol as Symbol
-import qualified Unison.Term as Term
+import qualified Unison.Var as Var
 
 data Sort = Type | Term deriving (Eq,Ord,Show)
 
-data Metadata k =
+data Metadata v r =
   Metadata {
     sort :: Sort,
-    names :: Names,
-    locals :: [(Term.Path, Symbol)],
-    description :: Maybe k
+    names :: Names v,
+    description :: Maybe r
   } deriving (Eq,Ord,Show)
 
-matches :: Query -> Metadata k -> Bool
-matches (Query txt) (Metadata _ (Names ns) _ _) =
-  any (Text.isPrefixOf txt) (map Symbol.name ns)
+matches :: Var v => Query -> Metadata v r -> Bool
+matches (Query txt) (Metadata _ (Names ns) _) =
+  any (Text.isPrefixOf txt) (map Var.name ns)
 
 -- | Nameless metadata, contains only the annotation
-synthetic :: Sort -> Metadata k
-synthetic t = Metadata t (Names []) [] Nothing
+synthetic :: Sort -> Metadata v r
+synthetic t = Metadata t (Names []) Nothing
 
 -- | Nameless term metadata, containing only the type annotation
-syntheticTerm :: Metadata k
+syntheticTerm :: Metadata v r
 syntheticTerm = synthetic Term
 
-data Names = Names [Symbol] deriving (Eq,Ord,Show)
+data Names v = Names [v] deriving (Eq,Ord,Show)
 
 data Query = Query Text
 

--- a/shared/src/Unison/Symbol.hs
+++ b/shared/src/Unison/Symbol.hs
@@ -34,7 +34,7 @@ instance Functor Symbol where
 instance Eq (Symbol a) where
   Symbol id1 name1 _ == Symbol id2 name2 _ = id1 == id2 && name1 == name2
 instance Ord (Symbol a) where
-  Symbol id1 name1 _ <= Symbol id2 name2 _ = id1 <= id2 || name1 <= name2
+  Symbol id1 name1 _ `compare` Symbol id2 name2 _ = (id1,name1) `compare` (id2,name2)
 
 instance Show (Symbol (Maybe a)) where
   show s | freshId s == 0 = Text.unpack (name s)

--- a/shared/src/Unison/Symbol.hs
+++ b/shared/src/Unison/Symbol.hs
@@ -1,15 +1,31 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE FlexibleInstances #-}
 module Unison.Symbol where
 
 import Data.Aeson.TH
 import Data.Text (Text)
-import Data.Set (Set)
+import Unison.Var (Var(..))
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 
 -- NB: freshId is first field, so given a `Set Symbol`, the max element of
 -- the set will also have the highest `freshId`.
-data Symbol a = Symbol { freshId :: !Int, name :: Text, annotation :: a }
+data Symbol a = Symbol !Int Text a
+
+freshId :: Symbol a -> Int
+freshId (Symbol id _ _) = id
+
+annotation :: Symbol a -> a
+annotation (Symbol _ _ a) = a
+
+instance Var (Symbol (Maybe a)) where
+  name (Symbol _ n _) = n
+  named n = Symbol 0 n Nothing
+  qualifiedName s = name s `Text.append` (Text.pack (show (freshId s)))
+  freshIn vs s | Set.null vs = s -- already fresh!
+  freshIn vs s | Set.notMember s vs = s -- already fresh!
+  freshIn vs s@(Symbol i n a) = case Set.elemAt (Set.size vs - 1) vs of
+    Symbol i2 _ _ -> if i > i2 then s else Symbol (i2+1) n a
 
 instance Functor Symbol where
   fmap f (Symbol id name a) = Symbol id name (f a)
@@ -20,22 +36,12 @@ instance Eq (Symbol a) where
 instance Ord (Symbol a) where
   Symbol id1 name1 _ <= Symbol id2 name2 _ = id1 <= id2 || name1 <= name2
 
-instance Show (Symbol a) where
+instance Show (Symbol (Maybe a)) where
   show s | freshId s == 0 = Text.unpack (name s)
   show s = Text.unpack (name s) ++ show (freshId s)
 
 symbol :: Text -> Symbol ()
 symbol n = Symbol 0 n ()
-
--- | Returns a fresh version of the given symbol, guaranteed to
--- be distinct from all symbols in the given set. Takes time
--- logarithmic in the size of the symbol set.
-freshIn :: Set (Symbol a) -> Symbol a2 -> Symbol a2
-freshIn vs s | Set.null vs = s -- already fresh!
-freshIn vs s |
-  Set.notMember (s { annotation = annotation (Set.findMin vs) }) vs = s -- already fresh!
-freshIn vs s@(Symbol i n a) = case Set.elemAt (Set.size vs - 1) vs of
-  Symbol i2 _ _ -> if i > i2 then s else Symbol (i2+1) n a
 
 prefix :: Text -> Symbol ()
 prefix name = symbol name

--- a/shared/src/Unison/Symbol.hs
+++ b/shared/src/Unison/Symbol.hs
@@ -7,29 +7,37 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 
-data Fixity = InfixL | InfixR | Infix | Prefix deriving (Eq,Ord,Show,Enum)
-
 -- NB: freshId is first field, so given a `Set Symbol`, the max element of
 -- the set will also have the highest `freshId`.
-data Symbol = Symbol { freshId :: !Int, name :: Text, fixity :: !Fixity, precedence :: !Int } deriving (Eq,Ord)
+data Symbol a = Symbol { freshId :: !Int, name :: Text, annotation :: a }
 
-instance Show Symbol where
+instance Functor Symbol where
+  fmap f (Symbol id name a) = Symbol id name (f a)
+
+-- Note: The `annotation` field not part of identity, is "just" metadata
+instance Eq (Symbol a) where
+  Symbol id1 name1 _ == Symbol id2 name2 _ = id1 == id2 && name1 == name2
+instance Ord (Symbol a) where
+  Symbol id1 name1 _ <= Symbol id2 name2 _ = id1 <= id2 || name1 <= name2
+
+instance Show (Symbol a) where
   show s | freshId s == 0 = Text.unpack (name s)
   show s = Text.unpack (name s) ++ show (freshId s)
 
-symbol :: Text -> Fixity -> Int -> Symbol
-symbol n f p = Symbol 0 n f p
+symbol :: Text -> Symbol ()
+symbol n = Symbol 0 n ()
 
 -- | Returns a fresh version of the given symbol, guaranteed to
 -- be distinct from all symbols in the given set. Takes time
 -- logarithmic in the size of the symbol set.
-freshIn :: Set Symbol -> Symbol -> Symbol
-freshIn vs s | Set.notMember s vs = s -- already fresh!
-freshIn vs s@(Symbol i n f p) = case Set.elemAt (Set.size vs - 1) vs of
-  Symbol i2 _ _ _ -> if i > i2 then s else Symbol (i2+1) n f p
+freshIn :: Set (Symbol a) -> Symbol a2 -> Symbol a2
+freshIn vs s | Set.null vs = s -- already fresh!
+freshIn vs s |
+  Set.notMember (s { annotation = annotation (Set.findMin vs) }) vs = s -- already fresh!
+freshIn vs s@(Symbol i n a) = case Set.elemAt (Set.size vs - 1) vs of
+  Symbol i2 _ _ -> if i > i2 then s else Symbol (i2+1) n a
 
-prefix :: Text -> Symbol
-prefix name = symbol name Prefix 9
+prefix :: Text -> Symbol ()
+prefix name = symbol name
 
-deriveJSON defaultOptions ''Fixity
 deriveJSON defaultOptions ''Symbol

--- a/shared/src/Unison/Term.hs
+++ b/shared/src/Unison/Term.hs
@@ -267,7 +267,7 @@ betaReduce e = e
 deriveJSON defaultOptions ''Literal
 
 instance Var v => Eq1 (F v) where (==#) = (==)
-instance Show v => Show1 (F v) where showsPrec1 = showsPrec
+instance Var v => Show1 (F v) where showsPrec1 = showsPrec
 
 deriveToJSON defaultOptions ''F
 instance (Ord v, FromJSON v, FromJSON r) => FromJSON (F v r) where
@@ -283,7 +283,7 @@ instance Show Literal where
   show (Number n) = show n
   show (Distance d) = show d
 
-instance (Show v, Show a) => Show (F v a) where
+instance (Var v, Show a) => Show (F v a) where
   showsPrec p fa = go p fa where
     go _ (Lit l) = showsPrec 0 l
     go p (Ann t k) = showParen (p > 1) $ showsPrec 0 t <> s":" <> showsPrec 0 k

--- a/shared/src/Unison/Type.hs
+++ b/shared/src/Unison/Type.hs
@@ -67,7 +67,7 @@ freeVars = ABT.freeVars
 
 data Monotype v = Monotype { getPolytype :: Type v } deriving (Eq)
 
-instance Show v => Show (Monotype v) where
+instance Var v => Show (Monotype v) where
   show = show . getPolytype
 
 -- Smart constructor which checks if a `Type` has no `Forall` quantifiers.

--- a/shared/src/Unison/Typechecker.hs
+++ b/shared/src/Unison/Typechecker.hs
@@ -33,7 +33,7 @@ invalid loc ctx = "invalid path " ++ show loc ++ " in:\n" ++ show ctx
 --
 -- Note: the returned type may contain free type variables, since
 -- we strip off any outer foralls.
-admissibleTypeAt :: (Applicative f, Show v, Var v)
+admissibleTypeAt :: (Applicative f, Var v)
                  => Type.Env f v
                  -> Term.Path
                  -> Term v
@@ -49,7 +49,7 @@ admissibleTypeAt synth loc t = Note.scoped ("admissibleTypeAt@" ++ show loc ++ "
     Just t -> shake <$> synthesize synth t
 
 -- | Compute the type of the given subterm.
-typeAt :: (Applicative f, Show v, Var v) => Type.Env f v -> Term.Path -> Term v -> Noted f (Type v)
+typeAt :: (Applicative f, Var v) => Type.Env f v -> Term.Path -> Term v -> Noted f (Type v)
 typeAt synth [] t = Note.scoped ("typeAt: " ++ show t) $ synthesize synth t
 typeAt synth loc t = Note.scoped ("typeAt@"++show loc ++ " " ++ show t) $
   let
@@ -62,7 +62,7 @@ typeAt synth loc t = Note.scoped ("typeAt@"++show loc ++ " " ++ show t) $
     Just t -> shake <$> synthesize synth t
 
 -- | Return the type of all local variables in scope at the given location
-locals :: (Applicative f, Show v, Var v) => Type.Env f v -> Term.Path -> Term v -> Noted f [(v, Type v)]
+locals :: (Applicative f, Var v) => Type.Env f v -> Term.Path -> Term v -> Noted f [(v, Type v)]
 locals synth path ctx | ABT.isClosed ctx =
   Note.scoped ("locals@"++show path ++ " " ++ show ctx)
               (zip (map fst lambdas) <$> lambdaTypes)
@@ -75,7 +75,7 @@ locals synth path ctx | ABT.isClosed ctx =
     lambdaTypes = traverse t (map snd lambdas)
       where t path = extract <$> typeAt synth path ctx
 
-    extract :: Show v => Type v -> Type v
+    extract :: Var v => Type v -> Type v
     extract (Type.Arrow' i _) = i
     extract (Type.Forall' _ t) = extract t
     extract t = error $ "expecting function type, got " ++ show t
@@ -85,12 +85,12 @@ locals _ _ ctx =
 -- | Infer the type of a 'Unison.Syntax.Term', using
 -- a function to resolve the type of @Ref@ constructors
 -- contained in that term.
-synthesize :: (Applicative f, Show v, Var v) => Type.Env f v -> Term v -> Noted f (Type v)
+synthesize :: (Applicative f, Var v) => Type.Env f v -> Term v -> Noted f (Type v)
 synthesize = Context.synthesizeClosed
 
 -- | Infer the type of a 'Unison.Syntax.Term', assumed
 -- not to contain any @Ref@ constructors
-synthesize' :: (Show v, Var v) => Term v -> Either Note (Type v)
+synthesize' :: Var v => Term v -> Either Note (Type v)
 synthesize' term = join . Note.unnote $ synthesize missing term
   where missing h = Note.failure $ "unexpected ref: " ++ show h
 
@@ -98,18 +98,18 @@ synthesize' term = join . Note.unnote $ synthesize missing term
 -- function to resolve the type of @Ref@ constructors
 -- contained in the term. Returns @typ@ if successful,
 -- and a note about typechecking failure otherwise.
-check :: (Applicative f, Show v, Var v) => Type.Env f v -> Term v -> Type v -> Noted f (Type v)
+check :: (Applicative f, Var v) => Type.Env f v -> Term v -> Type v -> Noted f (Type v)
 check synth term typ = synthesize synth (Term.ann term typ)
 
 -- | Check whether a term, assumed to contain no @Ref@ constructors,
 -- matches a given type. Return @Left@ if any references exist, or
 -- if typechecking fails.
-check' :: (Show v, Var v) => Term v -> Type v -> Either Note (Type v)
+check' :: Var v => Term v -> Type v -> Either Note (Type v)
 check' term typ = join . Note.unnote $ check missing term typ
   where missing h = Note.failure $ "unexpected ref: " ++ show h
 
 -- | Returns `True` if the expression is well-typed, `False` otherwise
-wellTyped :: (Monad f, Show v, Var v) => Type.Env f v -> Term v -> Noted f Bool
+wellTyped :: (Monad f, Var v) => Type.Env f v -> Term v -> Noted f Bool
 wellTyped synth term = (const True <$> synthesize synth term) `Note.orElse` pure False
 
 -- | @subtype a b@ is @Right b@ iff @f x@ is well-typed given
@@ -119,13 +119,13 @@ wellTyped synth term = (const True <$> synthesize synth term) `Note.orElse` pure
 -- about the reason for subtyping failure otherwise.
 --
 -- Example: @subtype (forall a. a -> a) (Int -> Int)@ returns @Right (Int -> Int)@.
-subtype :: (Show v, Var v) => Type v -> Type v -> Either Note (Type v)
+subtype :: Var v => Type v -> Type v -> Either Note (Type v)
 subtype t1 t2 = case Context.subtype (Context.context []) t1 t2 of
   Left e -> Left e
   Right _ -> Right t2
 
 -- | Returns true if @subtype t1 t2@ returns @Right@, false otherwise
-isSubtype :: (Show v, Var v) => Type v -> Type v -> Bool
+isSubtype :: Var v => Type v -> Type v -> Bool
 isSubtype t1 t2 = case Context.subtype (Context.context []) t1 t2 of
   Left _ -> False
   Right _ -> True
@@ -134,6 +134,6 @@ isSubtype t1 t2 = case Context.subtype (Context.context []) t1 t2 of
 -- order of quantifier introduction. Note that alpha equivalence considers:
 -- `forall b a . a -> b -> a` and
 -- `forall a b . a -> b -> a` to be different types
-equals :: (Show v, Var v) => Type v -> Type v -> Bool
+equals :: Var v => Type v -> Type v -> Bool
 equals t1 t2 = isSubtype t1 t2 && isSubtype t2 t1
 

--- a/shared/src/Unison/Typechecker/Context.hs
+++ b/shared/src/Unison/Typechecker/Context.hs
@@ -15,10 +15,11 @@ import Unison.Note (Note,Noted(..))
 import Unison.Term (Term)
 import Unison.Type (Type, Monotype(..))
 import Unison.Var (Var)
-import qualified Unison.ABT as ABT
 import qualified Data.Foldable as Foldable
-import qualified Unison.Note as Note
 import qualified Data.Set as Set
+import qualified Data.Text as Text
+import qualified Unison.ABT as ABT
+import qualified Unison.Note as Note
 import qualified Unison.Term as Term
 import qualified Unison.Type as Type
 import qualified Unison.Var as Var
@@ -36,11 +37,11 @@ data Element v
   | Marker v deriving (Eq) -- used for scoping
 
 instance Var v => Show (Element v) where
-  show (Universal v) = show (Var.shortName v)
-  show (Existential v) = "'"++show (Var.shortName v)
-  show (Solved v t) = "'"++show (Var.shortName v)++" = "++show t
-  show (Ann v t) = show (Var.shortName v)++" : "++show t
-  show (Marker v) = "|"++show (Var.shortName v)++"|"
+  show (Universal v) = Text.unpack (Var.shortName v)
+  show (Existential v) = "'"++Text.unpack (Var.shortName v)
+  show (Solved v t) = "'"++Text.unpack (Var.shortName v)++" = "++show t
+  show (Ann v t) = Text.unpack (Var.shortName v)++" : "++show t
+  show (Marker v) = "|"++Text.unpack (Var.shortName v)++"|"
 
 (===) :: Eq v => Element v -> Element v -> Bool
 Existential v === Existential v2 | v == v2 = True
@@ -72,9 +73,7 @@ context0 :: Context v
 context0 = Context []
 
 instance Var v => Show (Context v) where
-  show c@(Context es) =
-    "Γ " ++ show (map Var.shortName $ Set.toList (usedVars c)) ++ "\n  "
-         ++ (intercalate "\n  " . map (show . fst)) (reverse es)
+  show (Context es) = "Γ \n" ++ (intercalate "\n  " . map (show . fst)) (reverse es)
 
 -- ctxOK :: Context -> Context
 -- ctxOK ctx = if wellformed ctx then ctx else error $ "not ok: " ++ show ctx

--- a/shared/src/Unison/Typechecker/Context.hs
+++ b/shared/src/Unison/Typechecker/Context.hs
@@ -14,6 +14,7 @@ import Data.Set (Set)
 import Unison.Note (Note,Noted(..))
 import Unison.Term (Term)
 import Unison.Type (Type, Monotype(..))
+import Unison.Var (Var)
 import qualified Unison.ABT as ABT
 import qualified Data.Foldable as Foldable
 import qualified Unison.Note as Note
@@ -26,21 +27,21 @@ import qualified Unison.Type as Type
 -- watch msg a = trace (msg ++ ":\n" ++ show a) a
 
 -- | Elements of an ordered algorithmic context
-data Element
-  = Universal ABT.V            -- `v` is universally quantified
-  | Existential ABT.V          -- `v` existential and unsolved
-  | Solved ABT.V Monotype      -- `v` is solved to some monotype
-  | Ann ABT.V Type             -- `v` has type `a`, which may be quantified
-  | Marker ABT.V deriving (Eq) -- used for scoping
+data Element v
+  = Universal v            -- `v` is universally quantified
+  | Existential v          -- `v` existential and unsolved
+  | Solved v (Monotype v)  -- `v` is solved to some monotype
+  | Ann v (Type v)         -- `v` has type `a`, which may be quantified
+  | Marker v deriving (Eq) -- used for scoping
 
-instance Show Element where
+instance Show v => Show (Element v) where
   show (Universal v) = show v
   show (Existential v) = "'"++show v
   show (Solved v t) = "'"++show v++" = "++show t
   show (Ann v t) = show v++" : "++show t
   show (Marker v) = "|"++show v++"|"
 
-(===) :: Element -> Element -> Bool
+(===) :: Eq v => Element v -> Element v -> Bool
 Existential v === Existential v2 | v == v2 = True
 Universal v   === Universal v2 | v == v2 = True
 Marker v      === Marker v2 | v == v2 = True
@@ -56,19 +57,20 @@ _ === _ = False
    is also a valid context, and a fresh name can be obtained just
    by inspecting the first `Info` in the list.
 -}
-newtype Context = Context [(Element, Info)]
+newtype Context v = Context [(Element v, Info v)]
 
-data Info = Info { existentialVars :: Set ABT.V -- set of existentials seen so far
-                 , universalVars :: Set ABT.V -- set of universals seen so far
-                 , allVars :: Set ABT.V -- all variables seen so far
-                 , isWellformed :: Bool -- whether the context so far is well-formed
-                 }
+data Info v =
+  Info { existentialVars :: Set v -- set of existentials seen so far
+       , universalVars :: Set v -- set of universals seen so far
+       , allVars :: Set v -- all variables seen so far
+       , isWellformed :: Bool -- whether the context so far is well-formed
+       }
 
 -- | The empty context
-context0 :: Context
+context0 :: Context v
 context0 = Context []
 
-instance Show Context where
+instance Show v => Show (Context v) where
   show c@(Context es) =
     "Γ " ++ show (Set.toList (usedVars c)) ++ "\n  "
          ++ (intercalate "\n  " . map (show . fst)) (reverse es)
@@ -76,17 +78,17 @@ instance Show Context where
 -- ctxOK :: Context -> Context
 -- ctxOK ctx = if wellformed ctx then ctx else error $ "not ok: " ++ show ctx
 
-usedVars :: Context -> Set ABT.V
+usedVars :: Context v -> Set v
 usedVars = allVars . info
 
 -- | Return the `Info` associated with the last element of the context, or the zero `Info`.
-info :: Context -> Info
+info :: Context v -> Info v
 info (Context []) = Info Set.empty Set.empty Set.empty True
 info (Context ((_,i):_)) = i
 
 -- | Add an element onto the end of this `Context`. Takes `O(log N)` time,
 -- including updates to the accumulated `Info` value.
-extend :: Element -> Context -> Context
+extend :: (Show v, Var v) => Element v -> Context v -> Context v
 extend e c@(Context ctx) = Context ((e,i'):ctx) where
   i' = addInfo e (info c)
   -- see figure 7
@@ -105,44 +107,44 @@ extend e c@(Context ctx) = Context ((e,i'):ctx) where
     Marker v -> Info es us (Set.insert v vs) (ok && Set.notMember v vs)
 
 -- | Build a context from a list of elements.
-context :: [Element] -> Context
+context :: (Show v, Var v) => [Element v] -> Context v
 context xs = foldl' (flip extend) context0 xs
 
 -- | `append c1 c2` adds the elements of `c2` onto the end of `c1`.
-append :: Context -> Context -> Context
+append :: (Show v, Var v) => Context v -> Context v -> Context v
 append ctxL (Context es) =
   -- since `es` is a snoc list, we add it to `ctxL` in reverse order
   foldl' f ctxL (reverse es) where
     f ctx (e,_) = extend e ctx
 
 -- Generate a fresh variable of the given name, guaranteed fresh wrt `ctx`.
-fresh :: ABT.V -> Context -> ABT.V
+fresh :: Var v => v -> Context v -> v
 fresh v ctx = ABT.fresh' (usedVars ctx) v
 
 -- Generate two fresh variables of the given names, guaranteed fresh wrt `ctx`.
-fresh2 :: ABT.V -> ABT.V -> Context -> (ABT.V, ABT.V)
+fresh2 :: Var v => v -> v -> Context v -> (v, v)
 fresh2 va vb ctx = case fresh va ctx of
   va -> (va, ABT.fresh' (Set.insert va (usedVars ctx)) vb)
 
 -- Generate three fresh variables of the given names, guaranteed fresh wrt `ctx`.
-fresh3 :: ABT.V -> ABT.V -> ABT.V -> Context -> (ABT.V, ABT.V, ABT.V)
+fresh3 :: Var v => v -> v -> v -> Context v -> (v, v, v)
 fresh3 va vb vc ctx = case fresh2 va vb ctx of
   (va, vb) -> (va, vb, ABT.fresh' (Set.insert va . Set.insert vb $ usedVars ctx) vc)
 
 -- | Extend this `Context` with a single universally quantified variable,
 -- guaranteed to be fresh
-extendUniversal :: ABT.V -> Context -> (ABT.V, Context)
+extendUniversal :: (Show v, Var v) => v -> Context v -> (v, Context v)
 extendUniversal v ctx = case fresh v ctx of
   v -> (v, extend (Universal v) ctx)
 
 -- | Extend this `Context` with a marker variable, guaranteed to be fresh
-extendMarker :: ABT.V -> Context -> (ABT.V, Context)
+extendMarker :: (Show v, Var v) => v -> Context v -> (v, Context v)
 extendMarker v ctx = case fresh v ctx of
   v -> (v, ctx `append` context [Marker v, Existential v])
 
 -- | Delete from the end of this context up to and including
 -- the given `Element`. Returns `Left` if the element is not found.
-retract :: Element -> Context -> Either Note Context
+retract :: (Show v, Var v) => Element v -> Context v -> Either Note (Context v)
 retract m (Context ctx) =
   let maybeTail [] = Left $ Note.note ("unable to retract: " ++ show m)
       maybeTail (_:t) = Right t
@@ -151,26 +153,26 @@ retract m (Context ctx) =
   in Context <$> maybeTail (dropWhile (\(e,_) -> e /= m) ctx)
 
 -- | Like `retract`, but returns the empty context if retracting would remove all elements.
-retract' :: Element -> Context -> Context
+retract' :: (Show v, Var v) => Element v -> Context v -> Context v
 retract' e ctx = case retract e ctx of
   Left _ -> context []
   Right ctx -> ctx
 
-universals :: Context -> Set ABT.V
+universals :: Context v -> Set v
 universals = universalVars . info
 
-existentials :: Context -> Set ABT.V
+existentials :: Context v -> Set v
 existentials = existentialVars . info
 
-solved :: Context -> [(ABT.V, Monotype)]
+solved :: Context v -> [(v, Monotype v)]
 solved (Context ctx) = [(v, sa) | (Solved v sa,_) <- ctx]
 
-unsolved :: Context -> [ABT.V]
+unsolved :: Context v -> [v]
 unsolved (Context ctx) = [v | (Existential v,_) <- ctx]
 
 -- | Apply the context to the input type, then convert any unsolved existentials
 -- to universals.
-generalizeExistentials :: Context -> Type -> Type
+generalizeExistentials :: (Show v, Var v) => Context v -> Type v -> Type v
 generalizeExistentials ctx t = foldr gen (apply ctx t) (unsolved ctx)
   where
     gen e t =
@@ -178,10 +180,10 @@ generalizeExistentials ctx t = foldr gen (apply ctx t) (unsolved ctx)
       then Type.forall e (ABT.replace (Type.universal e) (Type.matchExistential e) t)
       else t -- don't bother introducing a forall if type variable is unused
 
-replace :: Element -> Context -> Context -> Context
+replace :: (Show v, Var v) => Element v -> Context v -> Context v -> Context v
 replace e focus ctx = let (l,r) = breakAt e ctx in l `append` focus `append` r
 
-breakAt :: Element -> Context -> (Context, Context)
+breakAt :: (Show v, Var v) => Element v -> Context v -> (Context v, Context v)
 breakAt m (Context xs) =
   let (r, l) = break (\(e,_) -> e === m) xs
   -- l is a suffix of xs and is already a valid context;
@@ -189,17 +191,17 @@ breakAt m (Context xs) =
   in (Context (drop 1 l), context . map fst $ reverse r)
 
 -- | ordered Γ α β = True <=> Γ[α^][β^]
-ordered :: Context -> ABT.V -> ABT.V -> Bool
+ordered :: (Show v, Var v) => Context v -> v -> v -> Bool
 ordered ctx v v2 = Set.member v (existentials (retract' (Existential v2) ctx))
 
 -- | Check that the context is well formed, see Figure 7 of paper
 -- Since contexts are 'monotonic', we can compute an cache this efficiently
 -- as the context is built up, see implementation of `extend`.
-wellformed :: Context -> Bool
+wellformed :: Context v -> Bool
 wellformed ctx = isWellformed (info ctx)
 
 -- | Check that the type is well formed wrt the given `Context`, see Figure 7 of paper
-wellformedType :: Context -> Type -> Bool
+wellformedType :: (Show v, Var v) => Context v -> Type v -> Bool
 wellformedType c t = wellformed c && case t of
   Type.Existential' v -> Set.member v (existentials c)
   Type.Universal' v -> Set.member v (universals c)
@@ -213,16 +215,16 @@ wellformedType c t = wellformed c && case t of
     in wellformedType ctx2 (ABT.replace (Type.universal v') (Type.matchUniversal v) t)
   _ -> error $ "Context.wellformedType - ill formed type - " ++ show t
 
-bindings :: Context -> [(ABT.V, Type)]
+bindings :: Context v -> [(v, Type v)]
 bindings (Context ctx) = [(v,a) | (Ann v a,_) <- ctx]
 
-lookupType :: Context -> ABT.V -> Maybe Type
+lookupType :: Eq v => Context v -> v -> Maybe (Type v)
 lookupType ctx v = lookup v (bindings ctx)
 
 -- | solve (ΓL,α^,ΓR) α τ = (ΓL,α = τ,ΓR)
 -- If the given existential variable exists in the context,
 -- we solve it to the given monotype, otherwise return `Nothing`
-solve :: Context -> ABT.V -> Monotype -> Maybe Context
+solve :: (Show v, Var v) => Context v -> v -> Monotype v -> Maybe (Context v)
 solve ctx v t
   | wellformedType ctxL (Type.getPolytype t) = Just ctx'
   | otherwise                                = Nothing
@@ -230,7 +232,7 @@ solve ctx v t
         ctx' = ctxL `append` context [Solved v t] `append` ctxR
 
 -- | Replace any existentials with their solution in the context
-apply :: Context -> Type -> Type
+apply :: (Ord v, Show v) => Context v -> Type v -> Type v
 apply ctx t = case t of
   Type.Universal' _ -> t
   Type.Lit' _ -> t
@@ -246,7 +248,7 @@ apply ctx t = case t of
 -- | `subtype ctx t1 t2` returns successfully if `t1` is a subtype of `t2`.
 -- This may have the effect of altering the context.
 -- see Figure 9
-subtype :: Context -> Type -> Type -> Either Note Context
+subtype :: (Show v, Var v) => Context v -> Type v -> Type v -> Either Note (Context v)
 subtype ctx tx ty = Note.scope (show tx++" <: "++show ty) (go tx ty) where -- Rules from figure 9
   go (Type.Lit' l) (Type.Lit' l2) | l == l2 = pure ctx -- `Unit`
   go t1@(Type.Universal' v1) t2@(Type.Universal' v2) -- `Var`
@@ -281,7 +283,7 @@ subtype ctx tx ty = Note.scope (show tx++" <: "++show ty) (go tx ty) where -- Ru
 -- | Instantiate the given existential such that it is
 -- a subtype of the given type, updating the context
 -- in the process.
-instantiateL :: Context -> ABT.V -> Type -> Either Note Context
+instantiateL :: (Var v, Show v) => Context v -> v -> Type v -> Either Note (Context v)
 instantiateL ctx v t = case Type.monotype t >>= solve ctx v of
   Just ctx' -> pure ctx' -- InstLSolve
   Nothing -> case t of
@@ -314,7 +316,7 @@ instantiateL ctx v t = case Type.monotype t >>= solve ctx v of
 -- | Instantiate the given existential such that it is
 -- a supertype of the given type, updating the context
 -- in the process.
-instantiateR :: Context -> Type -> ABT.V -> Either Note Context
+instantiateR :: (Show v, Var v) => Context v -> Type v -> v -> Either Note (Context v)
 instantiateR ctx t v = case Type.monotype t >>= solve ctx v of
   Just ctx' -> pure ctx' -- InstRSolve
   Nothing -> case t of
@@ -349,7 +351,7 @@ instantiateR ctx t v = case Type.monotype t >>= solve ctx v of
 
 -- | Check that under the given context, `e` has type `t`,
 -- updating the context in the process.
-check :: Context -> Term -> Type -> Either Note Context
+check :: (Show v, Var v) => Context v -> Term v -> Type v -> Either Note (Context v)
 check ctx e t | wellformedType ctx t = Note.scope ("check: " ++ show e ++ ":   " ++ show t) $ go e t where
   go (Term.Lit' l) _ = subtype ctx (synthLit l) t -- 1I
   go _ (Type.Forall' x body) = -- ForallI
@@ -384,7 +386,7 @@ check ctx e t = Note.scope ("context: " ++ show ctx) .
                 $ Left (Note.note "check failed")
 
 -- | Infer the type of a literal
-synthLit :: Term.Literal -> Type
+synthLit :: Ord v => Term.Literal -> Type v
 synthLit lit = Type.lit $ case lit of
   Term.Number _ -> Type.Number
   Term.Text _ -> Type.Text
@@ -395,7 +397,7 @@ synthLit lit = Type.lit $ case lit of
 -- their type. Also returns the freshened version of `body` and a marker
 -- which should be used to retract the context after checking/synthesis
 -- of `body` is complete. See usage in `synthesize` and `check` for `LetRec'` case.
-annotateLetRecBindings :: Context -> [(ABT.V, Term)] -> Term -> Either Note (Element, Term, Context)
+annotateLetRecBindings :: (Show v, Var v) => Context v -> [(v, Term v)] -> Term v -> Either Note (Element v, Term v, Context v)
 annotateLetRecBindings ctx bindings body = do
   -- freshen all the term variables `v1, v2 ...` used by each binding `b1, b2 ..`
   let vs = ABT.freshes' (usedVars ctx) (map fst bindings)
@@ -424,7 +426,7 @@ annotateLetRecBindings ctx bindings body = do
   pure $ (marker, body, ctx1 `append` context (marker : annotations))
 
 -- | Synthesize the type of the given term, updating the context in the process.
-synthesize :: Context -> Term -> Either Note (Type, Context)
+synthesize :: (Show v, Var v) => Context v -> Term v -> Either Note (Type v, Context v)
 synthesize ctx e = Note.scope ("synth: " ++ show e) $ go e where
   go (Term.Var' v) = case lookupType ctx v of -- Var
     Nothing -> Left $ Note.note "type not in scope"
@@ -479,7 +481,7 @@ synthesize ctx e = Note.scope ("synth: " ++ show e) $ go e where
 -- | Synthesize the type of the given term, `arg` given that a function of
 -- the given type `ft` is being applied to `arg`. Update the context in
 -- the process.
-synthesizeApp :: Context -> Type -> Term -> Either Note (Type, Context)
+synthesizeApp :: (Var v, Show v) => Context v -> Type v -> Term v -> Either Note (Type v, Context v)
 synthesizeApp ctx ft arg = go ft where
   go (Type.Forall' x body) = let x' = fresh x ctx -- Forall1App
     in synthesizeApp (ctx `append` context [Existential x'])
@@ -499,15 +501,14 @@ synthesizeApp ctx ft arg = go ft where
          , "function type: " ++ show ft
          , "arg: " ++ show arg ]
 
-annotateRefs :: Applicative f => Type.Env f -> Term -> Noted f Term
+annotateRefs :: (Applicative f, Ord v) => Type.Env f v -> Term v -> Noted f (Term v)
 annotateRefs synth term = ABT.visit f term where
   f (Term.Ref' h) = Just (Term.ann (Term.ref h) <$> synth h)
   f _ = Nothing
 
-synthesizeClosed :: Applicative f => Type.Env f -> Term -> Noted f Type
+synthesizeClosed :: (Applicative f, Show v, Var v) => Type.Env f v -> Term v -> Noted f (Type v)
 synthesizeClosed synthRef term = Noted $ synth <$> Note.unnote (annotateRefs synthRef term)
   where
-    synth :: Either Note Term -> Either Note Type
     synth (Left e) = Left e
     synth (Right a) = go <$> synthesize (context []) a
     go (t, ctx) = generalizeExistentials ctx t -- we generalize over any remaining unsolved existentials

--- a/shared/src/Unison/Var.hs
+++ b/shared/src/Unison/Var.hs
@@ -7,7 +7,12 @@ import qualified Data.Set as Set
 class (Eq v, Ord v) => Var v where
   named :: Text -> v
   name :: v -> Text
+  qualifiedName :: v -> Text
   freshIn :: Set v -> v -> v
+
+shortName :: Var v => v -> Text
+shortName v | named (name v) == v = name v
+shortName v = qualifiedName v
 
 freshes :: Var v => Set v -> [v] -> [v]
 freshes _ [] = []

--- a/shared/src/Unison/Var.hs
+++ b/shared/src/Unison/Var.hs
@@ -6,6 +6,7 @@ import qualified Data.Set as Set
 
 class (Eq v, Ord v) => Var v where
   named :: Text -> v
+  name :: v -> Text
   freshIn :: Set v -> v -> v
 
 freshes :: Var v => Set v -> [v] -> [v]

--- a/shared/src/Unison/Var.hs
+++ b/shared/src/Unison/Var.hs
@@ -1,0 +1,21 @@
+module Unison.Var where
+
+import Data.Set (Set)
+import Data.Text (Text)
+import qualified Data.Set as Set
+
+class (Eq v, Ord v) => Var v where
+  named :: Text -> v
+  freshIn :: Set v -> v -> v
+
+freshes :: Var v => Set v -> [v] -> [v]
+freshes _ [] = []
+freshes used (h:t) =
+  let h' = freshIn used h
+  in h' : freshes (Set.insert h' used) t
+
+freshInBoth :: Var v => Set v -> Set v -> v -> v
+freshInBoth vs1 vs2 = freshIn vs1 . freshIn vs2
+
+freshNamed :: Var v => Set v -> Text -> v
+freshNamed used n = freshIn used (named n)

--- a/shared/unison-shared.cabal
+++ b/shared/unison-shared.cabal
@@ -51,6 +51,7 @@ library
     Unison.Type
     Unison.Typechecker
     Unison.Typechecker.Context
+    Unison.Var
 
   build-depends:
     aeson,


### PR DESCRIPTION
This was a pretty tedious but straightforward change. Rather than hardcoding `Symbol` as the variable type used by `ABT`, it is now a parameter, bounded in most places with the typeclass `Var` (in `Unison.Var`). So we have `Term v` with variables in `v`, `Type v` with variables in `v`, etc. 

With `v` being the old `Symbol` type, we have the old behavior. But, `v` could add mixfix operators, or the generalized `Doc`-based layout I am going to be implementing next. This also makes it easy to fiddle with different precedence schemes if we want. The only code that is aware of the specific `v` will be the absolute top-level, which fixes `v` to some concrete type.

Something I considered but rejected was storing richer symbol layout outside of the syntax tree. This is really error prone - variables are getting moved around really often when editing, and keeping this richer information in sync is a nightmare. Better to store it in the tree directly, and just use parametricity to avoid coupling yourself to the details of that extra info.