### PR TITLE
fix #23 -- increase memory for vagrant box, provision as non-root & reorder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,13 +43,13 @@ Vagrant.configure(2) do |config|
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:
   #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
+   config.vm.provider "virtualbox" do |vb|
+     # Display the VirtualBox GUI when booting the machine
+     # vb.gui = true
+
+     # Customize the amount of memory on the VM:
+     vb.memory = "2048"
+   end
   #
   # View the documentation for the provider you are using for more
   # information on available options.
@@ -60,7 +60,7 @@ Vagrant.configure(2) do |config|
   # config.push.define "atlas" do |push|
   #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
   # end
-  config.vm.provision :shell, path: "vagrant-provision.sh"
+  config.vm.provision :shell, path: "vagrant-provision.sh", privileged: false
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.

--- a/vagrant-provision.sh
+++ b/vagrant-provision.sh
@@ -1,4 +1,5 @@
 sudo groupadd nixbld
 sudo usermod -a -G nixbld vagrant
-sudo -u vagrant curl https://nixos.org/nix/install | sh
+sudo mkdir /nix
 sudo chown -R vagrant /nix
+sudo -u vagrant curl https://nixos.org/nix/install | sh


### PR DESCRIPTION
The nix setup script doesn't like being run as root (event with sudo -u vagrant it still complains/aborts).

The extra memory is needed because compilation runs out otherwise. I didn't do an exhaustive search, it's possible it will run with less than the 2GB given.